### PR TITLE
vendor.lattice_machxo_2_3l: fix sdc generation

### DIFF
--- a/amaranth/build/plat.py
+++ b/amaranth/build/plat.py
@@ -426,6 +426,12 @@ class TemplatedPlatform(Platform):
         def tcl_quote(string):
             return '"' + re.sub(r"([$[\\])", r"\\\1", string) + '"'
 
+        def sdc_quote(string):
+            # synplify used in lattice diamond requires different quoting
+            # than standard tcl quoting: wrapped in curly braces but escaped
+            # as if wrapped in quotation marks.
+            return "{" + re.sub(r"([${}\\])", r"\\\1", string) + "}"
+
         def verbose(arg):
             if get_override_flag("verbose"):
                 return arg
@@ -448,6 +454,7 @@ class TemplatedPlatform(Platform):
                 compiled.environment.filters["ascii_escape"] = ascii_escape
                 compiled.environment.filters["tcl_escape"] = tcl_escape
                 compiled.environment.filters["tcl_quote"] = tcl_quote
+                compiled.environment.filters["sdc_quote"] = sdc_quote
             except jinja2.TemplateSyntaxError as e:
                 e.args = (f"{e.message} (at {origin}:{e.lineno})",)
                 raise

--- a/amaranth/vendor/_lattice_ecp5.py
+++ b/amaranth/vendor/_lattice_ecp5.py
@@ -234,6 +234,7 @@ class LatticeECP5Platform(TemplatedPlatform):
             {{get_override("add_preferences")|default("# (add_preferences placeholder)")}}
         """,
         "{{name}}.sdc": r"""
+            set_hierarchy_separator {/}
             {% for net_signal, port_signal, frequency in platform.iter_clock_constraints() -%}
                 {% if port_signal is not none -%}
                     create_clock -name {{port_signal.name|tcl_escape}} -period {{1000000000/frequency}} [get_ports {{port_signal.name|tcl_escape}}]

--- a/amaranth/vendor/_lattice_ecp5.py
+++ b/amaranth/vendor/_lattice_ecp5.py
@@ -237,9 +237,9 @@ class LatticeECP5Platform(TemplatedPlatform):
             set_hierarchy_separator {/}
             {% for net_signal, port_signal, frequency in platform.iter_clock_constraints() -%}
                 {% if port_signal is not none -%}
-                    create_clock -name {{port_signal.name|tcl_escape}} -period {{1000000000/frequency}} [get_ports {{port_signal.name|tcl_escape}}]
+                    create_clock -name {{port_signal.name|sdc_quote}} -period {{1000000000/frequency}} [get_ports {{port_signal.name|sdc_quote}}]
                 {% else -%}
-                    create_clock -name {{net_signal.name|tcl_escape}} -period {{1000000000/frequency}} [get_nets {{net_signal|hierarchy("/")|tcl_escape}}]
+                    create_clock -name {{net_signal.name|sdc_quote}} -period {{1000000000/frequency}} [get_nets {{net_signal|hierarchy("/")|sdc_quote}}]
                 {% endif %}
             {% endfor %}
             {{get_override("add_constraints")|default("# (add_constraints placeholder)")}}

--- a/amaranth/vendor/_lattice_machxo_2_3l.py
+++ b/amaranth/vendor/_lattice_machxo_2_3l.py
@@ -104,9 +104,9 @@ class LatticeMachXO2Or3LPlatform(TemplatedPlatform):
             set_hierarchy_separator {/}
             {% for net_signal, port_signal, frequency in platform.iter_clock_constraints() -%}
                 {% if port_signal is not none -%}
-                    create_clock -name {{port_signal.name|tcl_escape}} -period {{1000000000/frequency}} [get_ports {{port_signal.name|tcl_escape}}]
+                    create_clock -name {{port_signal.name|sdc_quote}} -period {{1000000000/frequency}} [get_ports {{port_signal.name|sdc_quote}}]
                 {% else -%}
-                    create_clock -name {{net_signal.name|tcl_escape}} -period {{1000000000/frequency}} [get_nets {{net_signal|hierarchy("/")|tcl_escape}}]
+                    create_clock -name {{net_signal.name|sdc_quote}} -period {{1000000000/frequency}} [get_nets {{net_signal|hierarchy("/")|sdc_quote}}]
                 {% endif %}
             {% endfor %}
             {{get_override("add_constraints")|default("# (add_constraints placeholder)")}}

--- a/amaranth/vendor/_lattice_machxo_2_3l.py
+++ b/amaranth/vendor/_lattice_machxo_2_3l.py
@@ -101,6 +101,7 @@ class LatticeMachXO2Or3LPlatform(TemplatedPlatform):
             {{get_override("add_preferences")|default("# (add_preferences placeholder)")}}
         """,
         "{{name}}.sdc": r"""
+            set_hierarchy_separator {/}
             {% for net_signal, port_signal, frequency in platform.iter_clock_constraints() -%}
                 {% if port_signal is not none -%}
                     create_clock -name {{port_signal.name|tcl_escape}} -period {{1000000000/frequency}} [get_ports {{port_signal.name|tcl_escape}}]


### PR DESCRIPTION
This PR fixes both issues reported in #546 .
Probably there is a similiar issue for ecp5 and ice40 since they both use synplify.