### PR TITLE
raise error on space in fsm name

### DIFF
--- a/nmigen/sim/pysim.py
+++ b/nmigen/sim/pysim.py
@@ -94,6 +94,8 @@ class _VCDWriter:
                 var_init = signal.reset
 
             for (*var_scope, var_name) in names:
+                if ' ' in var_name:
+                    raise ValueError("Variable '{}' cannot contain a space.".format(var_name))
                 suffix = None
                 while True:
                     try:


### PR DESCRIPTION
This testcase will throw an error on gtkwave start:

```python
from nmigen.sim import Delay, Simulator

class A(Elaboratable):
    def elaborate(self, _):
        m = Module()

        with m.FSM(name="space here"):
            with m.State(0):
                pass
        return m

if __name__ == "__main__":
    def proc():
        yield Delay(1e-4)

    m = Module()
    m.submodules.a = A()
    sim = Simulator(m)
    sim.add_process(proc)
    with sim.write_vcd("broken.vcd"):
        sim.run()
```

```
GTKWave Analyzer v3.3.108 (w)1999-2020 BSI

Near byte 172, $VAR parse error encountered with 'top.a.space'
No symbols in VCD file..nothing to do!
```

After this: nmigen will throw this error:

```
Traceback (most recent call last):
  File "/home/marcel/projects/fpgastuff/a.py", line 21, in <module>
    sim = Simulator(m)
  File "/home/marcel/projects/fpgastuff/.VE/lib/python3.9/site-packages/nmigen/sim/core.py", line 66, in __init__
    self._fragment = Fragment.get(fragment, platform=None).prepare()
  File "/home/marcel/projects/fpgastuff/.VE/lib/python3.9/site-packages/nmigen/hdl/ir.py", line 39, in get
    obj = obj.elaborate(platform)
  File "/home/marcel/projects/fpgastuff/.VE/lib/python3.9/site-packages/nmigen/hdl/dsl.py", line 540, in elaborate
    fragment.add_subfragment(Fragment.get(self._named_submodules[name], platform), name)
  File "/home/marcel/projects/fpgastuff/.VE/lib/python3.9/site-packages/nmigen/hdl/ir.py", line 39, in get
    obj = obj.elaborate(platform)
  File "/home/marcel/projects/fpgastuff/a.py", line 10, in elaborate
    with m.FSM(name="space here"):
  File "/usr/lib/python3.9/contextlib.py", line 117, in __enter__
    return next(self.gen)
  File "/home/marcel/projects/fpgastuff/.VE/lib/python3.9/site-packages/nmigen/hdl/dsl.py", line 361, in FSM
    raise ValueError("FSM name '{}' contains space, which is not allowed".format(name))
ValueError: FSM name 'space here' contains space, which is not allowed
```

Other character, even non visible, e.g. `\x03` seems fine, only a space `\x20` is bad.