### PR TITLE
Improve Instance driver-driver conflict error message

### DIFF
--- a/amaranth/hdl/ir.py
+++ b/amaranth/hdl/ir.py
@@ -394,7 +394,12 @@ class Fragment:
                 if sig not in defs:
                     defs[sig] = self
                 else:
-                    assert defs[sig] is self
+                    if defs[sig] is not self:
+                        raise SyntaxError(
+                            "Driver-driver conflict: trying to drive {!r}, but it is "
+                            "connected to the output of an Instance or an input pin"
+                            .format(sig))
+
 
         def add_io(*sigs):
             for sig in flatten(sigs):

--- a/tests/test_hdl_ir.py
+++ b/tests/test_hdl_ir.py
@@ -75,6 +75,20 @@ class FragmentDriversTestCase(FHDLTestCase):
         self.assertEqual(list(f.iter_comb()), [])
         self.assertEqual(list(f.iter_sync()), [])
 
+    def test_instance_conflict(self):
+        a = Signal()
+        f = Fragment()
+        m = Fragment()
+        i = Instance("test", o_aout = a)
+        m.add_subfragment(Fragment.get(i, None))
+        f.add_subfragment(Fragment.get(m, None))
+        f.add_statements(a.eq(1))
+
+        with self.assertRaisesRegex(SyntaxError,
+                r"^Driver-driver conflict: trying to drive \(sig a\), but it is connected to the "
+                "output of an Instance or an input pin$"):
+            f.prepare()
+
 
 class FragmentPortsTestCase(FHDLTestCase):
     def setUp(self):


### PR DESCRIPTION
This PR attempts to address issues #405 , #398 , and #320 by improving error messages for driver-driver conflicts involving Instances.

I took my best stab at a better message, but am totally open to changing it.

I am *almost* sure an Instance conflict is the only case in which this code path is hit (I called out "input pin" because while it's the same issue under the hood it looks different to the user), but please do review closely.

No rush on this - not sure if it makes sense to go into 0.3 or not.