### PR TITLE
sim: Implemented signal notability for use in generating actually useful GTKW files

### DIFF
--- a/nmigen/hdl/ast.py
+++ b/nmigen/hdl/ast.py
@@ -925,6 +925,9 @@ class Signal(Value, DUID):
         names). If an ``Enum`` subclass is passed, it is concisely decoded using format string
         ``"{0.name:}/{0.value:}"``, or a number if the signal value is not a member of
         the enumeration.
+    notable : None or bool or str
+        Indicates that this function is notable for storage in the gtkw file for simulation
+        and if so what group to place it in.
 
     Attributes
     ----------
@@ -938,7 +941,7 @@ class Signal(Value, DUID):
     """
 
     def __init__(self, shape=None, *, name=None, reset=0, reset_less=False,
-                 attrs=None, decoder=None, src_loc_at=0):
+                 attrs=None, decoder=None, notable=None, src_loc_at=0):
         super().__init__(src_loc_at=src_loc_at)
 
         if name is not None and not isinstance(name, str):
@@ -979,6 +982,17 @@ class Signal(Value, DUID):
         else:
             self.decoder = decoder
             self._enum_class = None
+
+        # Indicates that a signal is notable
+        if notable is not None:
+            if not isinstance(notable, bool) and not isinstance(notable, str):
+                raise TypeError("notable must be either None, bool, or str, not {!r}".format(type(notable)))
+
+            if notable:
+                if isinstance(notable, bool):
+                    self._notable = 'global'
+                else:
+                    self._notable = notable
 
     # Not a @classmethod because nmigen.compat requires it.
     @staticmethod

--- a/tests/test_sim.py
+++ b/tests/test_sim.py
@@ -807,3 +807,29 @@ class SimulatorRegressionTestCase(FHDLTestCase):
             self.assertEqual((yield -(Const(0b11, 2).as_signed())), 1)
         sim.add_process(process)
         sim.run()
+
+
+class SimulatorGTKWTestCase(FHDLTestCase):
+    def test_notable_signals(self):
+        m = Module()
+        nya = Signal(notable=True)
+        uwu = Signal()
+        umu = Signal(notable='owo')
+        flop = Signal(notable='owo')
+
+        m.d.sync += [
+            nya.eq(~nya),
+            umu.eq(~nya ^ flop),
+            uwu.eq(nya & umu),
+        ]
+
+        m.d.comb += [
+            flop.eq(~umu)
+        ]
+
+        sim = Simulator(m)
+
+        sim.add_clock(1 / 12e6, domain = "sync")
+
+        with sim.write_vcd("umu.vcd", "umu.gtkw"):
+            sim.run()


### PR DESCRIPTION
This adds a `notable` param to the `Signal` object which is then flattened into a dictionary of groups and signal names in the `pysim` engine for use in writing a GTKW file that contains only what you're interested in, rather than all of the signals in the design, or what has been specified when calling `write_vcd`.

You can specify the group for the signal, or just mark it as notable and it will be included in the `global` group by default when written out to the GTKW file.

A small example would be as follows:

```py
m = Module()
nya = Signal(notable=True)
awoo = Signal()

m.d.sync += [
    nya.eq(~nya),
    awoo.eq(nya),
]

sim = Simulator(m)

sim.add_clock(1 / 12e6, domain = "sync")

with sim.write_vcd("nya.vcd", "nya.gtkw"):
    sim.run()
```

There is also a functioning test case in the `tests/test_sim.py` file, and as of this commit all the tests still pass.
