### PR TITLE
sim: Add Observer

### DIFF
--- a/nmigen/sim/__init__.py
+++ b/nmigen/sim/__init__.py
@@ -1,4 +1,4 @@
 from .core import *
 
 
-__all__ = ["Settle", "Delay", "Tick", "Passive", "Active", "Simulator"]
+__all__ = ["Settle", "Delay", "Tick", "Passive", "Active", "Simulator", "Observer"]


### PR DESCRIPTION
Adds an Observer interface to the simulator, allowing arbitrary code
to receive values from the simulation.

The implementation is based on the implementation of write_vcd. An
obvious next step would be to make _VCDWriter a subclass of Observer,
then
- rewrite Simulator.write_vcd() as a call to Simulator.oberve()
- remove PySimEngine._vcd_writers and associated code.

This commit is an RFC for https://github.com/nmigen/nmigen/issues/327.
It is not intended to be submitted as-is.