### PR TITLE
fix reversed bit order in PriorityEncoder

### DIFF
--- a/nmigen/lib/coding.py
+++ b/nmigen/lib/coding.py
@@ -78,7 +78,7 @@ class PriorityEncoder(Elaboratable):
 
     def elaborate(self, platform):
         m = Module()
-        for j in reversed(range(self.width)):
+        for j in range(self.width):
             with m.If(self.i[j]):
                 m.d.comb += self.o.eq(j)
         m.d.comb += self.n.eq(self.i == 0)


### PR DESCRIPTION
After the change it works as expected:
![image](https://user-images.githubusercontent.com/148607/136649605-8eff1d38-cd59-4927-8b91-b02c94f58b42.png)
Slicing already has reversed bit numbering in comparison to verilog,
so the reversed function was not necessary.
Or, rather, because the last m.d.comb wins, that did the reversing.