### PR TITLE
back.{rtlil,verilog}: deprecate implicit ports.

### DIFF
--- a/amaranth/back/rtlil.py
+++ b/amaranth/back/rtlil.py
@@ -1,6 +1,7 @@
 import io
 from collections import OrderedDict
 from contextlib import contextmanager
+import warnings
 
 from .._utils import bits_for, flatten
 from ..hdl import ast, ir, mem, xfrm
@@ -1028,7 +1029,11 @@ def convert_fragment(fragment, name="top", *, emit_src=True):
     return str(builder), name_map
 
 
-def convert(elaboratable, name="top", platform=None, *, emit_src=True, **kwargs):
+def convert(elaboratable, name="top", platform=None, ports=None, *, emit_src=True, **kwargs):
+    # TODO(amaranth-0.4): remove
+    if ports is None:
+        warnings.warn("Implicit port determination is deprecated, specify ports explictly",
+                      DeprecationWarning, stacklevel=2)
     fragment = ir.Fragment.get(elaboratable, platform).prepare(**kwargs)
     il_text, name_map = convert_fragment(fragment, name, emit_src=emit_src)
     return il_text

--- a/amaranth/back/verilog.py
+++ b/amaranth/back/verilog.py
@@ -1,4 +1,7 @@
+import warnings
+
 from .._toolchain.yosys import *
+from ..hdl import ir
 from . import rtlil
 
 
@@ -39,6 +42,11 @@ def convert_fragment(*args, strip_internal_attrs=False, **kwargs):
     return _convert_rtlil_text(rtlil_text, strip_internal_attrs=strip_internal_attrs), name_map
 
 
-def convert(*args, strip_internal_attrs=False, **kwargs):
-    rtlil_text = rtlil.convert(*args, **kwargs)
-    return _convert_rtlil_text(rtlil_text, strip_internal_attrs=strip_internal_attrs)
+def convert(elaboratable, name="top", platform=None, ports=None, *, emit_src=True, strip_internal_attrs=False, **kwargs):
+    # TODO(amaranth-0.4): remove
+    if ports is None:
+        warnings.warn("Implicit port determination is deprecated, specify ports explictly",
+                      DeprecationWarning, stacklevel=2)
+    fragment = ir.Fragment.get(elaboratable, platform).prepare(**kwargs)
+    verilog_text, name_map = convert_fragment(fragment, name, emit_src=emit_src)
+    return verilog_text

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -71,7 +71,7 @@ class FHDLTestCase(unittest.TestCase):
             mode=mode,
             depth=depth,
             script=script,
-            rtlil=rtlil.convert(Fragment.get(spec, platform="formal"))
+            rtlil=rtlil.convert(Fragment.get(spec, platform="formal"), ports=())
         )
         with subprocess.Popen(
                 [require_tool("sby"), "-f", "-d", spec_name],


### PR DESCRIPTION
Fixes #630.