### PR TITLE
Fix 'ports' argument getting lost as it's no longer 'kwargs'

### DIFF
--- a/amaranth/back/rtlil.py
+++ b/amaranth/back/rtlil.py
@@ -1034,6 +1034,6 @@ def convert(elaboratable, name="top", platform=None, ports=None, *, emit_src=Tru
     if ports is None:
         warnings.warn("Implicit port determination is deprecated, specify ports explictly",
                       DeprecationWarning, stacklevel=2)
-    fragment = ir.Fragment.get(elaboratable, platform).prepare(**kwargs)
+    fragment = ir.Fragment.get(elaboratable, platform).prepare(ports=ports, **kwargs)
     il_text, name_map = convert_fragment(fragment, name, emit_src=emit_src)
     return il_text

--- a/amaranth/back/verilog.py
+++ b/amaranth/back/verilog.py
@@ -47,6 +47,6 @@ def convert(elaboratable, name="top", platform=None, ports=None, *, emit_src=Tru
     if ports is None:
         warnings.warn("Implicit port determination is deprecated, specify ports explictly",
                       DeprecationWarning, stacklevel=2)
-    fragment = ir.Fragment.get(elaboratable, platform).prepare(**kwargs)
+    fragment = ir.Fragment.get(elaboratable, platform).prepare(ports=ports, **kwargs)
     verilog_text, name_map = convert_fragment(fragment, name, emit_src=emit_src)
     return verilog_text


### PR DESCRIPTION
Fixes #658; because `ports` isn't part of `kwargs` any more it ends up going missing and, ironically, an implicitly determined set of ports is used instead.