### PR TITLE
sim.pysim: use "bench" as a top level root for testbench signals.

### DIFF
--- a/amaranth/sim/pysim.py
+++ b/amaranth/sim/pysim.py
@@ -19,7 +19,7 @@ class _NameExtractor:
     def __init__(self):
         self.names = SignalDict()
 
-    def __call__(self, fragment, *, hierarchy=("top",)):
+    def __call__(self, fragment, *, hierarchy=("bench", "top",)):
         def add_signal_name(signal):
             hierarchical_signal_name = (*hierarchy, signal.name)
             if signal not in self.names:
@@ -74,7 +74,7 @@ class _VCDWriter:
         trace_names = SignalDict()
         for trace in traces:
             if trace not in signal_names:
-                trace_names[trace] = {("top", trace.name)}
+                trace_names[trace] = {('bench', trace.name)}
             self.traces.append(trace)
 
         if self.vcd_writer is None:

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -70,6 +70,7 @@ Toolchain changes
 * Added: :meth:`build.BuildPlan.execute_remote_ssh`.
 * Deprecated: :class:`test.utils.FHDLTestCase`, with no replacement.
 * Deprecated: :func:`back.rtlil.convert()` and :func:`back.verilog.convert()` without an explicit `ports=` argument.
+* Changed: VCD output now uses a top-level "bench" module that contains testbench only signals.
 
 
 Platform integration changes

--- a/tests/test_sim.py
+++ b/tests/test_sim.py
@@ -849,7 +849,7 @@ class SimulatorRegressionTestCase(FHDLTestCase):
                 pass
         sim = Simulator(dut)
         with self.assertRaisesRegex(NameError,
-                r"^Signal 'top\.name with space_state' contains a whitespace character$"):
+                r"^Signal 'bench\.top\.name with space_state' contains a whitespace character$"):
             with open(os.path.devnull, "w") as f:
                 with sim.write_vcd(f):
                     sim.run()


### PR DESCRIPTION
Fixes #561.