### PR TITLE
Loosen dependency on Jinja2 version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         "importlib_metadata; python_version<'3.8'",  # for __version__ and amaranth._toolchain.yosys
         "importlib_resources; python_version<'3.9'", # for amaranth._toolchain.yosys
         "pyvcd~=0.2.2", # for amaranth.pysim
-        "Jinja2~=2.11", # for amaranth.build
+        "Jinja2>=2.11,<4.0", # for amaranth.build
     ],
     extras_require={
         # this version requirement needs to be synchronized with the one in amaranth.back.verilog!


### PR DESCRIPTION
For me also latest Jinja2 version is working fine and strict requirement of old version is conflicting with other libs using nmigen, e.g. https://github.com/lambdaconcept/lambdasoc/blob/master/setup.py