### PR TITLE
sim: Fix clock phase in add_clock having to be specified in ps. 

### DIFF
--- a/amaranth/sim/core.py
+++ b/amaranth/sim/core.py
@@ -139,6 +139,8 @@ class Simulator:
             # to happen at a non-zero time, distinguishing it from the reset values in the waveform
             # viewer.
             phase = period // 2
+        else:
+            phase = int(phase * 1e12) + period // 2
         self._engine.add_clock_process(domain.clk, phase=phase, period=period)
         self._clocked.add(domain)
 


### PR DESCRIPTION
Now more in line with the documentation, which states that the process will wait ``phase`` seconds.

Ref:
https://github.com/amaranth-lang/amaranth/blob/c83b51db6daf3b73fb2406fdeecf6ef7486bb0be/amaranth/sim/core.py#L104-L106

This was not true so far.
One had to give the clock phase wait time in ps.