### PR TITLE
Add a Pipeline helper to Module

### DIFF
--- a/amaranth/hdl/dsl.py
+++ b/amaranth/hdl/dsl.py
@@ -172,7 +172,7 @@ class Pipeline(_ModuleBuilderProxy):
 
     def _new_stage(self, name):
         self._state._stages.add(name)
-        new_stb = Signal(name=f"{name}_stb")
+        new_stb = Signal(name="{}_stb".format(name))
         if len(self._state._strobes) > 0:
             previous_stb = self._state._strobes[-1]
             self._state._builder_domain += new_stb.eq(previous_stb)
@@ -457,12 +457,12 @@ class Module(_ModuleBuilderRoot, Elaboratable):
             self._ctrl_context = "FSM"
 
     @contextmanager
-    def Pipeline(self, domain="sync", name="pipeline", *, stb):
+    def Pipeline(self, stb, name="pipeline", *, domain="sync"):
         self._check_context("Pipeline", context=None)
         if domain == "comb":
             raise ValueError("A pipeline may not be driven by the '{}' domain".format(domain))
 
-        output_stb = Signal(name=f"{name}_output_stb")
+        output_stb = Signal(name="{}_output_stb".format(name))
         pipeline = Pipeline(output_stb, self.d[domain], self.d.comb)
         self._set_ctrl("Pipeline", {
             "pipeline": pipeline,
@@ -493,7 +493,7 @@ class Module(_ModuleBuilderRoot, Elaboratable):
             name = f"STAGE{n}"
         
         if name in pipeline._state._stages:
-            raise NameError(f"Pipeline stage '{name}' is already defined")
+            raise NameError("Pipeline stage '{}' is already defined".format(name))
 
         try:
             self._ctrl_context = None

--- a/amaranth/hdl/dsl.py
+++ b/amaranth/hdl/dsl.py
@@ -474,10 +474,8 @@ class Module(_ModuleBuilderRoot, Elaboratable):
             self.domain._depth += 1
             yield pipeline
 
-            self.d.comb += [
-                output_stb.eq(pipeline._state._strobes[-1]),
-                pipeline._state._strobes[0].eq(stb),
-            ]
+            self.d[domain] += output_stb.eq(pipeline._state._strobes[-1]),
+            self.d.comb += pipeline._state._strobes[0].eq(stb)
         finally:
             self.domain._depth -= 1
             self._ctrl_context = None

--- a/amaranth/hdl/dsl.py
+++ b/amaranth/hdl/dsl.py
@@ -457,7 +457,7 @@ class Module(_ModuleBuilderRoot, Elaboratable):
             self._ctrl_context = "FSM"
 
     @contextmanager
-    def Pipeline(self, stb, name="pipeline", *, domain="sync"):
+    def Pipeline(self, stb, name="pipeline", domain="sync"):
         self._check_context("Pipeline", context=None)
         if domain == "comb":
             raise ValueError("A pipeline may not be driven by the '{}' domain".format(domain))

--- a/examples/basic/pipeline.py
+++ b/examples/basic/pipeline.py
@@ -22,7 +22,7 @@ class MulAdd(Elaboratable):
             with m.Stage("ADD_ONE"):
                 pln.added_one = pln.mul + 1
             with m.Stage("ADD"):
-                m.d.sync += self.o.eq(pln.mul + self.c)
+                m.d.sync += self.o.eq(pln.added_one + self.c)
             
             m.d.comb += self.o_stb.eq(pln.o_stb)
 

--- a/examples/basic/pipeline.py
+++ b/examples/basic/pipeline.py
@@ -22,7 +22,7 @@ class MulAdd(Elaboratable):
             with m.Stage("ADD_ONE"):
                 pln.added_one = pln.mul + 1
             with m.Stage("ADD"):
-                m.d.comb += self.o.eq(pln.mul + self.c)
+                m.d.sync += self.o.eq(pln.mul + self.c)
             
             m.d.comb += self.o_stb.eq(pln.o_stb)
 
@@ -41,6 +41,8 @@ if __name__ == "__main__":
         yield dut.stb.eq(1)
         yield
         yield dut.stb.eq(0)
+
+        yield
 
         yield dut.a.eq(11)
         yield dut.b.eq(2)

--- a/examples/basic/pipeline.py
+++ b/examples/basic/pipeline.py
@@ -21,6 +21,8 @@ class MulAdd(Elaboratable):
                 pln.mul = self.a * self.b
             with m.Stage("ADD_ONE"):
                 pln.added_one = pln.mul + 1
+                with m.If(pln.mul == 20):
+                    pln.stage_invalid()
             with m.Stage("ADD"):
                 m.d.sync += self.o.eq(pln.added_one + self.c)
             

--- a/examples/basic/pipeline.py
+++ b/examples/basic/pipeline.py
@@ -1,0 +1,61 @@
+from amaranth import *
+from amaranth.cli import main
+
+
+class MulAdd(Elaboratable):
+    def __init__(self, width):
+        self.a = Signal(width)
+        self.b = Signal(width)
+        self.c = Signal(width)
+        self.stb = Signal()
+        
+        self.o = Signal(width * 2 + 1)
+        self.o_stb = Signal()
+        self.width = width
+
+    def elaborate(self, platform):
+        m = Module()
+
+        with m.Pipeline(stb=self.stb) as pln:
+            with m.Stage():
+                pln.mul = self.a * self.b
+            with m.Stage("ADD_ONE"):
+                pln.added_one = pln.mul + 1
+            with m.Stage("ADD"):
+                m.d.comb += self.o.eq(pln.mul + self.c)
+            
+            m.d.comb += self.o_stb.eq(pln.o_stb)
+
+        return m
+
+
+if __name__ == "__main__":
+    from amaranth.sim import Simulator
+
+    dut = MulAdd(width=16)
+
+    def bench():
+        yield dut.a.eq(10)
+        yield dut.b.eq(2)
+        yield dut.c.eq(5)
+        yield dut.stb.eq(1)
+        yield
+        yield dut.stb.eq(0)
+
+        yield dut.a.eq(11)
+        yield dut.b.eq(2)
+        yield dut.c.eq(5)
+        yield dut.stb.eq(1)
+        yield
+        yield dut.stb.eq(0)
+
+        for _ in range(4):
+            yield
+
+    sim = Simulator(dut)
+    sim.add_clock(1e-6) # 1 MHz
+    sim.add_sync_process(bench)
+    with sim.write_vcd("pipeline.vcd"):
+        sim.run()
+
+    # main(muladd, ports=[muladd.a, muladd.b, muladd.c, muladd.stb, muladd.o, muladd.o_stb])

--- a/examples/basic/pipeline.py
+++ b/examples/basic/pipeline.py
@@ -16,7 +16,7 @@ class MulAdd(Elaboratable):
     def elaborate(self, platform):
         m = Module()
 
-        with m.Pipeline(stb=self.stb) as pln:
+        with m.Pipeline(self.stb) as pln:
             with m.Stage():
                 pln.mul = self.a * self.b
             with m.Stage("ADD_ONE"):


### PR DESCRIPTION
This adds two additional methods to `Module`:

```python
def Pipeline(self, stb, name="pipeline", domain="sync"):
    ...
def Stage(self, name=None):
    ...
```

These can to be used to easily create pipelined hardware, like so:

```python
class MulAdd(Elaboratable):
    def __init__(self, width):
        self.a = Signal(width)
        self.b = Signal(width)
        self.c = Signal(width)
        self.stb = Signal()
        
        self.o = Signal(width * 2 + 1)
        self.o_stb = Signal()
        self.width = width

    def elaborate(self, platform):
        m = Module()

        with m.Pipeline(self.stb) as pln:
            with m.Stage():
                pln.mul = self.a * self.b
            with m.Stage("ADD_ONE"):
                pln.added_one = pln.mul + 1
            with m.Stage("ADD"):
                m.d.sync += self.o.eq(pln.added_one + self.c)
            
            m.d.comb += self.o_stb.eq(pln.o_stb)

        return m
```

When the `stb` argument to `m.Pipeline()` is strobed, the pipeline starts on that clock cycle and progresses through the stages. Of course, multiple stages can be running at any given time.

For data to get pipelined through each stage, you set the `pipeline.<whatever name>` property with the value you want propagated forward through the stages. You can access any value you've set in a previous stage in any future stage. The signal is set within the clock domain that the pipeline was instantiated with.

The `pipeline.o_stb` property is a signal that is strobed a cycle after the last stage executes (I think that's the right behavior, let me know if not).

A stage can be made invalid by calling the `pipeline.invalid_stage()` method. This is, of course, propagated forward through the stages.