### PR TITLE
build.plat: use tool_env_var() in _toolchain_env_var.

### DIFF
--- a/amaranth/build/plat.py
+++ b/amaranth/build/plat.py
@@ -70,11 +70,11 @@ class Platform(ResourceManager, metaclass=ABCMeta):
 
     @property
     def _deprecated_toolchain_env_var(self):
-        return f"NMIGEN_ENV_{self.toolchain}"
+        return f"NMIGEN_ENV_{tool_env_var(self.toolchain)}"
 
     @property
     def _toolchain_env_var(self):
-        return f"AMARANTH_ENV_{self.toolchain}"
+        return f"AMARANTH_ENV_{tool_env_var(self.toolchain)}"
 
     def build(self, elaboratable, name="top",
               build_dir="build", do_build=True,


### PR DESCRIPTION
This allows `Platform.toolchain` to contain '+' or  '-' characters.