### PR TITLE
Fix Jinja2 dependency

### DIFF
--- a/amaranth/build/plat.py
+++ b/amaranth/build/plat.py
@@ -375,7 +375,7 @@ class TemplatedPlatform(Platform):
             else:
                 return jinja2.Undefined(name=var)
 
-        @jinja2.contextfunction
+        @jinja2.pass_context
         def invoke_tool(context, name):
             env_var = tool_env_var(name)
             if context.parent["syntax"] == "sh":

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         "importlib_metadata; python_version<'3.8'",  # for __version__ and amaranth._toolchain.yosys
         "importlib_resources; python_version<'3.9'", # for amaranth._toolchain.yosys
         "pyvcd~=0.2.2", # for amaranth.pysim
-        "Jinja2>=2.11,<4.0", # for amaranth.build
+        "Jinja2~=3.0",  # for amaranth.build
     ],
     extras_require={
         # this version requirement needs to be synchronized with the one in amaranth.back.verilog!


### PR DESCRIPTION
This PR fixes #688 by upgrading the Jinja2 dependency to minimum of major version 3, which does not have the issue with it's markupsafe dependency being  incorrect. In order to do this, update the uses of `@jinja2.contextfunction` to use the non-deprecated `@jinja2.pass_context` name instead, as this name will be removed in Jinja2 versions `>=3.1.0`.