### PR TITLE
Changelog update for new `debug_verilog` override

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,13 @@ Next version
 
 Support for Python 3.6 has been dropped.
 
+Toolchain changes
+-----------------
+
+.. currentmodule:: amaranth
+
+* Added: ``debug_verilog`` override in :class:`build.TemplatedPlatform`.
+
 
 Version 0.3
 ============


### PR DESCRIPTION
Missed this in the first PR. 