### PR TITLE
Cover `amaranth.build.dsl` with documentation

### DIFF
--- a/amaranth/lib/io.py
+++ b/amaranth/lib/io.py
@@ -54,7 +54,7 @@ class Pin(Record):
     or tristate buffers that may include a 1:n gearbox. (A 1:2 gearbox is typically called "DDR".)
 
     A :class:`Pin` is identical to a :class:`Record` that uses the corresponding :meth:`pin_layout`
-    except that it allos accessing the parameters like ``width`` as attributes. It is legal to use
+    except that it allows accessing the parameters like ``width`` as attributes. It is legal to use
     a plain :class:`Record` anywhere a :class:`Pin` is used, provided that these attributes are
     not necessary.
 

--- a/docs/buildsys.rst
+++ b/docs/buildsys.rst
@@ -1,0 +1,11 @@
+Build system
+############
+
+.. todo::
+
+   Write this section.
+
+.. toctree::
+   :maxdepth: 2
+
+   buildsys/dsl

--- a/docs/buildsys/dsl.rst
+++ b/docs/buildsys/dsl.rst
@@ -1,0 +1,29 @@
+Resource mapping and definitions
+################################
+
+.. py:module:: amaranth.build.dsl
+
+The :mod:`amaranth.build.dsl` module provides a fluent DSL for defining I/O resources that may be
+requested from a platform and their pinouts.
+
+
+Resource definitions
+====================
+
+.. autoclass:: Resource
+.. autoclass:: Subsignal
+
+
+Pin definitions
+===============
+.. autoclass:: Pins
+.. autoclass:: PinsN
+.. autoclass:: DiffPairs
+.. autoclass:: DiffPairsN
+
+
+Resource helpers
+================
+.. autoclass:: Connector
+.. autoclass:: Attrs
+.. autoclass:: Clock

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,5 +14,6 @@ Language & toolchain
    tutorial
    lang
    stdlib
+   buildsys
    platform
    changes


### PR DESCRIPTION
Starting to document the `amaranth.build` module and thought the DSL portion was a useful place to start since it's the most frequently encountered.

Due to Git issues I accidentally forced #696 to not exist so here's the fixed PR.