### PR TITLE
_toolchain.cxx: fix use of distutils.ccompiler on newer setuptools.

### DIFF
--- a/amaranth/_toolchain/cxx.py
+++ b/amaranth/_toolchain/cxx.py
@@ -20,8 +20,9 @@ def build_cxx(*, cxx_sources, output_name, include_dirs, macros):
         with warnings.catch_warnings():
             warnings.filterwarnings(action="ignore", category=DeprecationWarning)
             # This emits a DeprecationWarning on Python 3.10.
-            from setuptools import distutils
-            cc_driver = distutils.ccompiler.new_compiler()
+            import setuptools
+            from distutils import ccompiler
+            cc_driver = ccompiler.new_compiler()
 
         cc_driver.output_dir = "."
 


### PR DESCRIPTION
Starting with setuptools 64.0.2, the monkeypatching process performed as part of its bootstrap no longer imports distutils.ccompiler, causing an AttributeError.