### PR TITLE
lib.coding: remove GrayDecoder comb loop for consistency

### DIFF
--- a/amaranth/lib/coding.py
+++ b/amaranth/lib/coding.py
@@ -178,7 +178,8 @@ class GrayDecoder(Elaboratable):
 
     def elaborate(self, platform):
         m = Module()
-        m.d.comb += self.o[-1].eq(self.i[-1])
-        for i in reversed(range(self.width - 1)):
-            m.d.comb += self.o[i].eq(self.o[i + 1] ^ self.i[i])
+        rhs = Const(0)
+        for i in reversed(range(self.width)):
+            rhs = rhs ^ self.i[i]
+            m.d.comb += self.o[i].eq(rhs)
         return m


### PR DESCRIPTION
While developing a prototype for #704 at 052647445772cfe83767b0c55dd47c196763ac82, I discovered that bits of `Graydecoder.o` are combinationally dependent on each other. When each bit is thought of as an individual signal, this is no problem, but a comb loop detection pass would be slowed down by that assumption. Regardless of if it's within the scope of the language's "no *indirect* comb loops" policy, it is easily rewritable to never have assignments that have the output signal both on the left and righ-hand sides. That is what this PR contains. All tests pass, including the formal check of gray encoding reversibility, proving correctness of this PR.