### PR TITLE
hdl.ast: allow IntEnum/IntFlag in Cat.

### DIFF
--- a/amaranth/hdl/ast.py
+++ b/amaranth/hdl/ast.py
@@ -168,12 +168,12 @@ class Value(metaclass=ABCMeta):
         while True:
             if isinstance(obj, Value):
                 return obj
-            elif isinstance(obj, int):
-                return Const(obj)
-            elif isinstance(obj, Enum):
-                return Const(obj.value, Shape.cast(type(obj)))
             elif isinstance(obj, ValueCastable):
                 new_obj = obj.as_value()
+            elif isinstance(obj, Enum):
+                return Const(obj.value, Shape.cast(type(obj)))
+            elif isinstance(obj, int):
+                return Const(obj)
             else:
                 raise TypeError("Object {!r} cannot be converted to an Amaranth value".format(obj))
             if new_obj is obj:

--- a/amaranth/hdl/ast.py
+++ b/amaranth/hdl/ast.py
@@ -860,7 +860,7 @@ class Cat(Value):
         super().__init__(src_loc_at=src_loc_at)
         self.parts = []
         for index, arg in enumerate(flatten(args)):
-            if isinstance(arg, int) and arg not in [0, 1]:
+            if isinstance(arg, int) and not isinstance(arg, Enum) and arg not in [0, 1]:
                 warnings.warn("Argument #{} of Cat() is a bare integer {} used in bit vector "
                               "context; consider specifying explicit width using C({}, {}) instead"
                               .format(index + 1, arg, arg, bits_for(arg)),

--- a/docs/lang.rst
+++ b/docs/lang.rst
@@ -235,6 +235,9 @@ Casting a value from an integer ``i`` is a shorthand for ``Const(i)``:
    >>> Value.cast(5)
    (const 3'd5)
 
+.. note::
+
+   If a value subclasses :class:`enum.IntEnum` or its class otherwise inherits from both :class:`int` and :class:`Enum`, it is treated as an enumeration.
 
 Values from enumeration members
 -------------------------------
@@ -246,6 +249,10 @@ Casting a value from an enumeration member ``m`` is a shorthand for ``Const(m.va
    >>> Value.cast(Direction.LEFT)
    (const 2'd1)
 
+
+.. note::
+
+   If a value subclasses :class:`enum.IntEnum` or its class otherwise inherits from both :class:`int` and :class:`Enum`, it is treated as an enumeration.
 
 .. _lang-signals:
 

--- a/tests/test_hdl_ast.py
+++ b/tests/test_hdl_ast.py
@@ -23,6 +23,12 @@ class StringEnum(Enum):
     BAR = "b"
 
 
+class TypedEnum(int, Enum):
+    FOO = 1
+    BAR = 2
+    BAZ = 3
+
+
 class ShapeTestCase(FHDLTestCase):
     def test_make(self):
         s1 = Shape()
@@ -198,6 +204,11 @@ class ValueTestCase(FHDLTestCase):
         e2 = Value.cast(SignedEnum.FOO)
         self.assertIsInstance(e2, Const)
         self.assertEqual(e2.shape(), signed(2))
+
+    def test_cast_typedenum(self):
+        e1 = Value.cast(TypedEnum.FOO)
+        self.assertIsInstance(e1, Const)
+        self.assertEqual(e1.shape(), unsigned(2))
 
     def test_cast_enum_wrong(self):
         with self.assertRaisesRegex(TypeError,
@@ -780,6 +791,15 @@ class CatTestCase(FHDLTestCase):
         with warnings.catch_warnings():
             warnings.filterwarnings(action="error", category=SyntaxWarning)
             Cat(0, 1, 1, 0)
+
+    def test_enum(self):
+        class Color(Enum):
+            RED  = 1
+            BLUE = 2
+        with warnings.catch_warnings():
+            warnings.filterwarnings(action="error", category=SyntaxWarning)
+            c = Cat(Color.RED, Color.BLUE)
+        self.assertEqual(repr(c), "(cat (const 2'd1) (const 2'd2))")
 
     def test_int_wrong(self):
         with self.assertWarnsRegex(SyntaxWarning,

--- a/tests/test_hdl_ast.py
+++ b/tests/test_hdl_ast.py
@@ -801,6 +801,15 @@ class CatTestCase(FHDLTestCase):
             c = Cat(Color.RED, Color.BLUE)
         self.assertEqual(repr(c), "(cat (const 2'd1) (const 2'd2))")
 
+    def test_intenum(self):
+        class Color(int, Enum):
+            RED  = 1
+            BLUE = 2
+        with warnings.catch_warnings():
+            warnings.filterwarnings(action="error", category=SyntaxWarning)
+            c = Cat(Color.RED, Color.BLUE)
+        self.assertEqual(repr(c), "(cat (const 2'd1) (const 2'd2))")
+
     def test_int_wrong(self):
         with self.assertWarnsRegex(SyntaxWarning,
                 r"^Argument #1 of Cat\(\) is a bare integer 2 used in bit vector context; "


### PR DESCRIPTION
Example code that can make use of such changes:

```py
class Something(IntEnum):
    A = 0b1000
    B = 0b0000

...

class Component(Elaboratable):
    def elaborate(self, platform):
        m = Module()
        with m.Switch(...):
             with m.Case(Cat(Something.A, Something.B)):
                 ...
```

The first commit is more important to me than the second one (you can always work it around using `Case(Cat(...)._as_const())`), but they are pretty much independent, so if it is desirable to only merge one of them, you can do it.