### PR TITLE
Add support for explicit names in properties

### DIFF
--- a/amaranth/back/rtlil.py
+++ b/amaranth/back/rtlil.py
@@ -751,7 +751,7 @@ class _StatementCompiler(xfrm.StatementVisitor):
         self.state.rtlil.cell("$" + stmt._kind, ports={
             "\\A": check_wire,
             "\\EN": en_wire,
-        }, src=_src(stmt.src_loc))
+        }, src=_src(stmt.src_loc), name=stmt.name)
 
     on_Assert = on_property
     on_Assume = on_property

--- a/amaranth/hdl/ast.py
+++ b/amaranth/hdl/ast.py
@@ -1405,11 +1405,15 @@ class UnusedProperty(UnusedMustUse):
 class Property(Statement, MustUse):
     _MustUse__warning = UnusedProperty
 
-    def __init__(self, test, *, _check=None, _en=None, src_loc_at=0):
+    def __init__(self, test, *, _check=None, _en=None, name=None, src_loc_at=0):
         super().__init__(src_loc_at=src_loc_at)
         self.test   = Value.cast(test)
         self._check = _check
         self._en    = _en
+        self.name   = name
+        if not isinstance(self.name, str) and self.name is not None:
+            raise TypeError("Property name must be a string or None, not {!r}"
+                            .format(self.name))
         if self._check is None:
             self._check = Signal(reset_less=True, name="${}$check".format(self._kind))
             self._check.src_loc = self.src_loc
@@ -1424,6 +1428,8 @@ class Property(Statement, MustUse):
         return self.test._rhs_signals()
 
     def __repr__(self):
+        if self.name is not None:
+            return "({}: {} {!r})".format(self.name, self._kind, self.test)    
         return "({} {!r})".format(self._kind, self.test)
 
 

--- a/amaranth/hdl/xfrm.py
+++ b/amaranth/hdl/xfrm.py
@@ -237,13 +237,13 @@ class StatementTransformer(StatementVisitor):
         return Assign(self.on_value(stmt.lhs), self.on_value(stmt.rhs))
 
     def on_Assert(self, stmt):
-        return Assert(self.on_value(stmt.test), _check=stmt._check, _en=stmt._en)
+        return Assert(self.on_value(stmt.test), _check=stmt._check, _en=stmt._en, name=stmt.name)
 
     def on_Assume(self, stmt):
-        return Assume(self.on_value(stmt.test), _check=stmt._check, _en=stmt._en)
+        return Assume(self.on_value(stmt.test), _check=stmt._check, _en=stmt._en, name=stmt.name)
 
     def on_Cover(self, stmt):
-        return Cover(self.on_value(stmt.test), _check=stmt._check, _en=stmt._en)
+        return Cover(self.on_value(stmt.test), _check=stmt._check, _en=stmt._en, name=stmt.name)
 
     def on_Switch(self, stmt):
         cases = OrderedDict((k, self.on_statement(s)) for k, s in stmt.cases.items())


### PR DESCRIPTION
This PR implements explicit naming of properties (Assert/Assume/Cover) as asked in #744. The name is specified through the use of a new optional parameter "name".

With the following code example:
```python
from amaranth import *
from amaranth.asserts import *
from amaranth.back import rtlil

m = Module()
a = Signal()
m.d.sync += Assert(a != 0, name="foobar")

print(rtlil.convert(m, ports=(a,)))
```

The `$assert` cell picks up the proper name:

```
[...]
  cell $assert \foobar
    connect \A $assert$check
    connect \EN $assert$en
  end
[...]
```

Fixes #744.