### PR TITLE
build.run: Handle UTF-8 encoding errors in SSH output gracefully

### DIFF
--- a/amaranth/build/run.py
+++ b/amaranth/build/run.py
@@ -176,7 +176,7 @@ class BuildPlan:
                 # Show the output from the server while products are built.
                 buf = channel.recv(1024)
                 while buf:
-                    print(buf.decode("utf-8"), end="")
+                    print(buf.decode("utf-8", errors="replace"), end="")
                     buf = channel.recv(1024)
 
         return RemoteSSHBuildProducts(connect_to, root)


### PR DESCRIPTION
In some cases, a toolchain might produce shell output that isn't correct UTF-8. To avoid crashing in such cases, pass errors="replace" to bytes.decode.

For example, Lattice Diamond uses the Latin-1 encoding for some reason. This recently broke my setup because the month turned to "März" in a German locale:

--- Start Time: Fr. M�r 3 20:01:41 2023