### PR TITLE
docs: disambiguate Cat(a, b, ...) support for more than 2 arguments

### DIFF
--- a/docs/lang.rst
+++ b/docs/lang.rst
@@ -707,7 +707,7 @@ Operation               Description                                      Notes
 
 .. [#opS1] Words "length" and "width" have the same meaning when talking about Amaranth values. Conventionally, "width" is used.
 .. [#opS2] All variations of the Python slice notation are supported, including "extended slicing". E.g. all of ``a[0]``, ``a[1:9]``, ``a[2:]``, ``a[:-2]``, ``a[::-1]``, ``a[0:8:2]`` select bits in the same way as other Python sequence types select their elements.
-.. [#opS3] In the concatenated value, ``a`` occupies the least significant bits, and ``b`` the most significant bits.
+.. [#opS3] In the concatenated value, ``a`` occupies the least significant bits, and ``b`` the most significant bits. Any number of arguments (zero, one, two, or more) are supported.
 
 For the operators introduced by Amaranth, the following table explains them in terms of Python code operating on tuples of bits rather than Amaranth values:
 


### PR DESCRIPTION
I had this confusion while reading the doc.

Someone else also likely had, unless there was a change at some point:
https://github.com/bl0x/learn-fpga-amaranth/blob/main/06_alu/soc.py#L111