### PR TITLE
Improve handling of documentation on CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -60,6 +60,9 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Pull tags from upstream repository
+        run: |
+          git pull --tags https://github.com/amaranth-lang/amaranth.git
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -107,3 +110,25 @@ jobs:
           branch: main
           folder: docs/
           target-folder: docs/amaranth/v${{ env.VERSION }}/
+  publish-docs-dev:
+    needs: document
+    if: github.repository != 'amaranth-lang/amaranth'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Download documentation archive
+        uses: actions/download-artifact@v3
+        with:
+          name: docs
+          path: pages/docs/${{ github.ref_name }}/
+      - name: Disable Jekyll
+        run: |
+          touch pages/.nojekyll
+      - name: Publish documentation for a branch
+        uses: JamesIves/github-pages-deploy-action@releases/v4
+        with:
+          folder: pages/
+          clean: false

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -98,9 +98,6 @@ jobs:
           branch: main
           folder: docs/
           target-folder: docs/amaranth/latest/
-      - name: Extract release version
-        if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
-        run: echo "VERSION=$(python setup.py --version)" >>$GITHUB_ENV
       - name: Publish release documentation
         if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
         uses: JamesIves/github-pages-deploy-action@releases/v4
@@ -109,7 +106,7 @@ jobs:
           ssh-key: ${{ secrets.PAGES_DEPLOY_KEY }}
           branch: main
           folder: docs/
-          target-folder: docs/amaranth/v${{ env.VERSION }}/
+          target-folder: docs/amaranth/${{ github.ref_name }}/
   publish-docs-dev:
     needs: document
     if: github.repository != 'amaranth-lang/amaranth'

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -71,6 +71,21 @@ jobs:
       - name: Build documentation
         run: |
           sphinx-build docs docs/_build
+      - name: Upload documentation archive
+        uses: actions/upload-artifact@v3
+        with:
+          name: docs
+          path: docs/_build
+  publish-docs:
+    needs: document
+    if: github.repository == 'amaranth-lang/amaranth'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download documentation archive
+        uses: actions/download-artifact@v3
+        with:
+          name: docs
+          path: docs/
       - name: Publish development documentation
         if: github.event_name == 'push' && github.event.ref == 'refs/heads/main'
         uses: JamesIves/github-pages-deploy-action@releases/v4
@@ -78,7 +93,7 @@ jobs:
           repository-name: amaranth-lang/amaranth-lang.github.io
           ssh-key: ${{ secrets.PAGES_DEPLOY_KEY }}
           branch: main
-          folder: docs/_build
+          folder: docs/
           target-folder: docs/amaranth/latest/
       - name: Extract release version
         if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
@@ -90,5 +105,5 @@ jobs:
           repository-name: amaranth-lang/amaranth-lang.github.io
           ssh-key: ${{ secrets.PAGES_DEPLOY_KEY }}
           branch: main
-          folder: docs/_build
+          folder: docs/
           target-folder: docs/amaranth/v${{ env.VERSION }}/


### PR DESCRIPTION
Docs are now uploaded as an artifact (zip archive you can download from the Actions tab), and in forks, they are also pushed to the gh-pages branch and can be previewed that way.