### PR TITLE
build.plat: replace -+ characters in _all_toolchain_env_vars.

### DIFF
--- a/amaranth/build/plat.py
+++ b/amaranth/build/plat.py
@@ -76,7 +76,10 @@ class Platform(ResourceManager, metaclass=ABCMeta):
     # TODO(amaranth-0.5): remove
     @property
     def _all_toolchain_env_vars(self):
-        return (f"AMARANTH_ENV_{self.toolchain}", self._toolchain_env_var,)
+        return (
+            f"AMARANTH_ENV_{self.toolchain.replace('-', '_').replace('+', 'X')}",
+            self._toolchain_env_var,
+        )
 
     def build(self, elaboratable, name="top",
               build_dir="build", do_build=True,


### PR DESCRIPTION
Mixed-case variables are allowed since af7c1144, but '-' or '+' must be replaced to avoid invalid names (e.g. "$AMARANTH_ENV_oss-cad-suite").

See also #729.