### PR TITLE
Allow pyvcd 0.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ requires-python = "~=3.7"
 dependencies = [
   "importlib_metadata;  python_version<'3.8'", # for __version__ and amaranth._toolchain.yosys
   "importlib_resources; python_version<'3.9'", # for amaranth._toolchain.yosys
-  "pyvcd>=0.2.2,<0.4", # for amaranth.sim.pysim
+  "pyvcd>=0.2.2,<0.5", # for amaranth.sim.pysim
   "Jinja2~=3.0", # for amaranth.build
 ]
 


### PR DESCRIPTION
The only breaking change in 0.4 is dropping support for Python 3.6, which Amaranth has already dropped. It also adds official support for 3.10 and 3.11.

https://github.com/westerndigitalcorporation/pyvcd/blob/3ad7340072791e695e32cfb51135b751a8ddab41/CHANGELOG.rst