### PR TITLE
hdl.ast: fix range handling in `Shape.cast`.

### DIFF
--- a/amaranth/hdl/ast.py
+++ b/amaranth/hdl/ast.py
@@ -117,9 +117,9 @@ class Shape:
             elif isinstance(obj, range):
                 if len(obj) == 0:
                     return Shape(0, obj.start < 0)
-                signed = obj.start < 0 or (obj.stop - obj.step) < 0
-                width  = max(bits_for(obj.start, signed),
-                             bits_for(obj.stop - obj.step, signed))
+                signed = obj[0] < 0 or obj[-1] < 0
+                width  = max(bits_for(obj[0], signed),
+                             bits_for(obj[-1], signed))
                 return Shape(width, signed)
             elif isinstance(obj, type) and issubclass(obj, Enum):
                 # For compatibility with third party enumerations, handle them as if they were

--- a/tests/test_hdl_ast.py
+++ b/tests/test_hdl_ast.py
@@ -117,6 +117,9 @@ class ShapeTestCase(FHDLTestCase):
         s7 = Shape.cast(range(-1, -1))
         self.assertEqual(s7.width, 0)
         self.assertEqual(s7.signed, True)
+        s8 = Shape.cast(range(0, 10, 3))
+        self.assertEqual(s8.width, 4)
+        self.assertEqual(s8.signed, False)
 
     def test_cast_enum(self):
         s1 = Shape.cast(UnsignedEnum)


### PR DESCRIPTION
Fixes #803.