### PR TITLE
hdl.ast: fix signed `Const` normalization.

### DIFF
--- a/amaranth/hdl/ast.py
+++ b/amaranth/hdl/ast.py
@@ -647,7 +647,7 @@ class Const(Value):
             shape = Shape.cast(shape, src_loc_at=1 + src_loc_at)
         self.width  = shape.width
         self.signed = shape.signed
-        if self.signed and self.value >> (self.width - 1):
+        if self.signed and self.value >> (self.width - 1) & 1:
             self.value |= -(1 << self.width)
         else:
             self.value &= (1 << self.width) - 1

--- a/tests/test_hdl_ast.py
+++ b/tests/test_hdl_ast.py
@@ -369,6 +369,8 @@ class ConstTestCase(FHDLTestCase):
 
     def test_normalization(self):
         self.assertEqual(Const(0b10110, signed(5)).value, -10)
+        self.assertEqual(Const(0b10000, signed(4)).value, 0)
+        self.assertEqual(Const(-16, 4).value, 0)
 
     def test_value(self):
         self.assertEqual(Const(10).value, 10)


### PR DESCRIPTION
Fixes #805.