### PR TITLE
hdl.ast: fix `Slice` validation.

### DIFF
--- a/amaranth/hdl/ast.py
+++ b/amaranth/hdl/ast.py
@@ -794,11 +794,11 @@ class Slice(Value):
             raise TypeError("Slice stop must be an integer, not {!r}".format(stop))
 
         n = len(value)
-        if start not in range(-(n+1), n+1):
+        if start not in range(-n, n+1):
             raise IndexError("Cannot start slice {} bits into {}-bit value".format(start, n))
         if start < 0:
             start += n
-        if stop not in range(-(n+1), n+1):
+        if stop not in range(-n, n+1):
             raise IndexError("Cannot stop slice {} bits into {}-bit value".format(stop, n))
         if stop < 0:
             stop += n

--- a/tests/test_hdl_ast.py
+++ b/tests/test_hdl_ast.py
@@ -703,6 +703,9 @@ class SliceTestCase(FHDLTestCase):
         with self.assertRaisesRegex(IndexError,
                 r"^Slice start 4 must be less than slice stop 2$"):
             Slice(c, 4, 2)
+        with self.assertRaisesRegex(IndexError,
+                r"^Cannot start slice -9 bits into 8-bit value$"):
+            Slice(c, -9, -5)
 
     def test_repr(self):
         s1 = Const(10)[2]


### PR DESCRIPTION
Fixes #810.