### PR TITLE
Support non-initialisable memories

### DIFF
--- a/amaranth/back/rtlil.py
+++ b/amaranth/back/rtlil.py
@@ -877,7 +877,7 @@ def _convert_fragment(builder, fragment, name_map, hierarchy):
                         if memory not in memories:
                             memories[memory] = module.memory(width=memory.width, size=memory.depth,
                                                              name=memory.name, attrs=memory.attrs)
-                            if memory.init:
+                            if memory.init is not None:
                                 addr_bits = bits_for(memory.depth)
                                 data_parts = []
                                 data_mask = (1 << memory.width) - 1

--- a/amaranth/back/rtlil.py
+++ b/amaranth/back/rtlil.py
@@ -877,26 +877,27 @@ def _convert_fragment(builder, fragment, name_map, hierarchy):
                         if memory not in memories:
                             memories[memory] = module.memory(width=memory.width, size=memory.depth,
                                                              name=memory.name, attrs=memory.attrs)
-                            addr_bits = bits_for(memory.depth)
-                            data_parts = []
-                            data_mask = (1 << memory.width) - 1
-                            for addr in range(memory.depth):
-                                if addr < len(memory.init):
-                                    data = memory.init[addr] & data_mask
-                                else:
-                                    data = 0
-                                data_parts.append("{:0{}b}".format(data, memory.width))
-                            module.cell("$meminit", ports={
-                                "\\ADDR": rhs_compiler(ast.Const(0, addr_bits)),
-                                "\\DATA": "{}'".format(memory.width * memory.depth) +
-                                          "".join(reversed(data_parts)),
-                            }, params={
-                                "MEMID": memories[memory],
-                                "ABITS": addr_bits,
-                                "WIDTH": memory.width,
-                                "WORDS": memory.depth,
-                                "PRIORITY": 0,
-                            })
+                            if memory.init:
+                                addr_bits = bits_for(memory.depth)
+                                data_parts = []
+                                data_mask = (1 << memory.width) - 1
+                                for addr in range(memory.depth):
+                                    if addr < len(memory.init):
+                                        data = memory.init[addr] & data_mask
+                                    else:
+                                        data = 0
+                                    data_parts.append("{:0{}b}".format(data, memory.width))
+                                module.cell("$meminit", ports={
+                                    "\\ADDR": rhs_compiler(ast.Const(0, addr_bits)),
+                                    "\\DATA": "{}'".format(memory.width * memory.depth) +
+                                            "".join(reversed(data_parts)),
+                                }, params={
+                                    "MEMID": memories[memory],
+                                    "ABITS": addr_bits,
+                                    "WIDTH": memory.width,
+                                    "WORDS": memory.depth,
+                                    "PRIORITY": 0,
+                                })
 
                         param_value = memories[memory]
 

--- a/tests/test_hdl_mem.py
+++ b/tests/test_hdl_mem.py
@@ -43,6 +43,14 @@ class MemoryTestCase(FHDLTestCase):
                     r"'str' object cannot be interpreted as an integer$")):
             m = Memory(width=8, depth=4, init=[1, "0"])
 
+    def test_init_default(self):
+        m = Memory(width=8, depth=4)
+        self.assertIsNone(m.init)
+
+    def test_init_empty(self):
+        m = Memory(width=8, depth=4, init=[])
+        self.assertEqual(m.init, [])
+
     def test_attrs(self):
         m1 = Memory(width=8, depth=4)
         self.assertEqual(m1.attrs, {})


### PR DESCRIPTION
In order to use memory types that don't support initialisation (e.g. iCE40 SPRAM), we need to be able to create memories without initialising them.

In a1e2c75, we check for a truthy `memory.init`, as the default value (`None`) is coalesced to `[]` in the setter:

https://github.com/amaranth-lang/amaranth/blob/b1cce87630e917dfe09546cd78c73c7a310c6b97/amaranth/hdl/mem.py#L66-L68

We could equally check if `len(memory.init) > 0`.

### Potential for breaking behaviour?

This does have the _potential_ for wider-reaching impact on behaviour, for memory types that do support initialisation. Previously, a `None` or empty init would explicitly zero-initialise the entire memory, and indeed, in simulation this will still be the case, but now no `$meminit` cell would be emitted and the exact behaviour is defined by the backend/target. To explicitly force zero-init as currently happens, one would need to supply at minimum `Memory(init=[0])`.

In _practice_, after Yosys is done, e.g. for `SB_RAM40_4K`, the `INIT_0`–`INIT_F` parameters to the target memory cell become `xxxx...`. By the time nextpnr is done with it, the corresponding `.ram_data` in the bitstream have all zeroes.

### Changed meaning of `init` values

I've included a second commit 1021e34, which is even more of a suggestion than the first, which updates the docstring/tests and modifies the behaviour of the attribute slightly. This moves the boundary of behaviour change; we now distinguish between:

* `init=None` (no explicit initialisation), and
* `init=[]` (zero-init).

The type of `Memory.init` now also admits `None`, which might bite users whose code relied on reading back their `memory.init` assuming it would always be a `list[int]`.

Assuming it's OK to rely on the assumption "_initialisable RAM cells that aren't explicitly initialised will get zero-initted anyway later on in the process by the backend_" like above, I think the reasonable choice is to keep the default `init=None`. The API is conceptually simple: no `init` specified means no specified initialisation.

#### Note on possible futures

There could be surprising consequences if that assumption stops holding. Continuing with the `SB_RAM40_4K` example, even though currently initial data is always included in the bitstream output by the Yosys/nextpnr flow, [Memory Usage Guide for iCE40 Devices](https://www.latticesemi.com/-/media/LatticeSemi/Documents/ApplicationNotes/MO/MemoryUsageGuideforiCE40Devices.ashx?document_id=47775) (p6) suggests this is optional. If this optionality were realised down the track, in sum these changes would mean EBR that was previously reliably zero-initialised would cease to be so.

Thus, depending on our tolerance for possibly breaking changes, we may prefer a default of `init=[]`, which will zero-initialise all storage elements like the current default. Uninitialised memory would be opt-in only. There would still be the potential to break existing Amaranth designs (i.e. under the above scenario where the backend behaviour changes), as users may be explicitly passing `None` expecting zero-init.


### Alternative solutions

* Add a sentinel value for the `init` parameter (e.g. `mem.UNINITIALIZED`) and retain all existing behaviour.
  * This maxes out on backwards compatibility, at the cost of adding an edge to the API.
  * It's clean, and reinforces that Amaranth has a separate semantics to its backends; i.e. memories _are_ zero-init unless explicitly requested otherwise.
    * This is good in the "self-consistent and predictable by default" sense, bad in the "more to learn/be surprised by for old-timers" sense.
    * It seems to me like we want this property especially when it comes to interop with the native Python environment (hence treatment of indexing, exclusive ranges, sequence order, etc.), but I'm not clear on e.g. just how abstract we want something like a `Memory` to seem.
* Do nothing.
  * Uninitialisable memories continue to require the use of `Instance` and are not usable with Amaranth memory primitives.