### PR TITLE
sim._pyrtl: py3.12+: convert to int before bitwise negating.

### DIFF
--- a/amaranth/sim/_pyrtl.py
+++ b/amaranth/sim/_pyrtl.py
@@ -138,7 +138,7 @@ class _RHSValueCompiler(_ValueCompiler):
         if len(value.operands) == 1:
             arg, = value.operands
             if value.operator == "~":
-                return f"(~{self(arg)})"
+                return f"(~{mask(arg)})"
             if value.operator == "-":
                 return f"(-{sign(arg)})"
             if value.operator == "b":

--- a/tests/test_sim.py
+++ b/tests/test_sim.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from contextlib import contextmanager
 
 from amaranth._utils import flatten
@@ -871,6 +872,15 @@ class SimulatorIntegrationTestCase(FHDLTestCase):
             with open(os.path.devnull, "w") as f:
                 with sim.write_vcd(f):
                     pass
+
+    def test_no_negated_boolean_warning(self):
+        m = Module()
+        a = Signal()
+        b = Signal()
+        m.d.comb += a.eq(~(b == b))
+        with warnings.catch_warnings(record=True) as warns:
+            Simulator(m).run()
+            self.assertEqual(warns, [])
 
 
 class SimulatorRegressionTestCase(FHDLTestCase):


### PR DESCRIPTION
Amaranth bitwise negation `~` compiles to Python bitwise negation `~` in simulation; the same holds for comparison operators such as `==`. Thus an expression such as `~(a == b)` in simulation will compile to Python that takes the bitwise negation of the comparison result, which will be an actual bool.

On 3.12, the result is a `DeprecationWarning` emitted only at simulation run-time.

When negating in simulation, coerce the value to an int. `mask` is sufficient as we do no further arithmetic here.