### PR TITLE
sim._pyrtl: mask bitwise binary operands.

### DIFF
--- a/amaranth/sim/_pyrtl.py
+++ b/amaranth/sim/_pyrtl.py
@@ -166,11 +166,11 @@ class _RHSValueCompiler(_ValueCompiler):
             if value.operator == "%":
                 return f"zmod({sign(lhs)}, {sign(rhs)})"
             if value.operator == "&":
-                return f"({self(lhs)} & {self(rhs)})"
+                return f"({mask(lhs)} & {mask(rhs)})"
             if value.operator == "|":
-                return f"({self(lhs)} | {self(rhs)})"
+                return f"({mask(lhs)} | {mask(rhs)})"
             if value.operator == "^":
-                return f"({self(lhs)} ^ {self(rhs)})"
+                return f"({mask(lhs)} ^ {mask(rhs)})"
             if value.operator == "<<":
                 return f"({sign(lhs)} << {sign(rhs)})"
             if value.operator == ">>":

--- a/tests/test_sim.py
+++ b/tests/test_sim.py
@@ -927,3 +927,12 @@ class SimulatorRegressionTestCase(FHDLTestCase):
                 r"^Adding a clock process that drives a clock domain object named 'sync', "
                 r"which is distinct from an identically named domain in the simulated design$"):
             sim.add_clock(1e-6, domain=ClockDomain("sync"))
+
+    def test_bug_826(self):
+        sim = Simulator(Module())
+        def process():
+            self.assertEqual((yield C(0b0000, 4) | ~C(1, 1)), 0b0000)
+            self.assertEqual((yield C(0b1111, 4) & ~C(1, 1)), 0b0000)
+            self.assertEqual((yield C(0b1111, 4) ^ ~C(1, 1)), 0b1111)
+        sim.add_process(process)
+        sim.run()


### PR DESCRIPTION
Addresses the bug surfaced in https://github.com/amaranth-lang/amaranth/pull/826#issuecomment-1603634393.

I read through the remaining value compiler branches (and poked at a few things to see if I could break them), but I believe it's all OK from here.