### PR TITLE
sim._pyrtl: don't blow parser stack on older Pythons.

### DIFF
--- a/amaranth/sim/_pyrtl.py
+++ b/amaranth/sim/_pyrtl.py
@@ -83,7 +83,11 @@ class _ValueCompiler(ValueVisitor, _Compiler):
                                 "simulate in reasonable time"
                                 .format(src, len(value)))
 
-        return super().on_value(value)
+        v = super().on_value(value)
+        if isinstance(v, str) and len(v) > 1000:
+            # Avoid parser stack overflow on older Pythons.
+            return self.emitter.def_var("intermediate", v)
+        return v
 
     def on_ClockSignal(self, value):
         raise NotImplementedError # :nocov:

--- a/tests/test_sim.py
+++ b/tests/test_sim.py
@@ -882,6 +882,19 @@ class SimulatorIntegrationTestCase(FHDLTestCase):
             Simulator(m).run()
             self.assertEqual(warns, [])
 
+    def test_large_expr_parser_overflow(self):
+        m = Module()
+        a = Signal()
+
+        op = a
+        for _ in range(50):
+            op = (op ^ 1)
+
+        op = op & op
+
+        m.d.comb += a.eq(op)
+        Simulator(m)
+
 
 class SimulatorRegressionTestCase(FHDLTestCase):
     def test_bug_325(self):


### PR DESCRIPTION

Python pre-3.9 can't handle parentheses nested this deeply.

* https://github.com/amaranth-lang/amaranth/pull/681 -- motivating example.
* https://github.com/amaranth-lang/amaranth/pull/827 -- what added enough extra parentheses to make this only break now.
* https://peps.python.org/pep-0617/ -- new parser as of 3.9.