### PR TITLE
lib.enum: allow `import * from amaranth.lib.enum`.

### DIFF
--- a/amaranth/lib/enum.py
+++ b/amaranth/lib/enum.py
@@ -7,9 +7,9 @@ from ..hdl.ast import Value, Shape, ShapeCastable, Const
 __all__ = py_enum.__all__
 
 
-for member in py_enum.__all__:
-    globals()[member] = getattr(py_enum, member)
-del member
+for _member in py_enum.__all__:
+    globals()[_member] = getattr(py_enum, _member)
+del _member
 
 
 class EnumMeta(ShapeCastable, py_enum.EnumMeta):


### PR DESCRIPTION
There's an actual `py_enum.member` (which we briefly overwrite our loop index with (!)).  We delete our `member`, but it's still in the `__all__` that came from `py_enum`, so `import *` fails.