### PR TITLE
lib.io: allow 0-width `Pin`

### DIFF
--- a/amaranth/lib/io.py
+++ b/amaranth/lib/io.py
@@ -12,8 +12,8 @@ def pin_layout(width, dir, xdr=0):
 
     See :class:`Pin` for details.
     """
-    if not isinstance(width, int) or width < 1:
-        raise TypeError("Width must be a positive integer, not {!r}"
+    if not isinstance(width, int) or width < 0:
+        raise TypeError("Width must be a non-negative integer, not {!r}"
                         .format(width))
     if dir not in ("i", "o", "oe", "io"):
         raise TypeError("Direction must be one of \"i\", \"o\", \"io\", or \"oe\", not {!r}"""


### PR DESCRIPTION
The main purpose of this change is migrating glasgow from the compat `TSTriple` (which allows 0 width) to `Pin`.  This sort of change would normally require a RFC, but `Pin` is already slated for removal/replacement, so that was deemed to be unnecessary.
