### PR TITLE
recognize Artix Ultrascale+ part numbers

### DIFF
--- a/amaranth/vendor/xilinx.py
+++ b/amaranth/vendor/xilinx.py
@@ -606,7 +606,7 @@ class XilinxPlatform(TemplatedPlatform):
                 self.family = "ultrascaleplus"
             else:
                 self.family = "ultrascale"
-        elif device.startswith(("zu", "u", "k26")):
+        elif device.startswith(("zu", "u", "k26", "au")):
             self.family = "ultrascaleplus"
         elif device.startswith(("v", "2s")):
             # Match last to avoid conflict with ultrascale.


### PR DESCRIPTION
They don't allow use of URAM288s, have the transceivers capped to 16.3 Gb/s but otherwise are simply smaller versions of Kintex US+. I don't believe any other changes are needed.

XCAU20P, XCAU25P are XCKU5P die with different device ID and software limitations
XCAU7P-15P are new parts