### PR TITLE
build.run: make `BuildPlan.execute_local(env=)` override environment

### DIFF
--- a/amaranth/build/run.py
+++ b/amaranth/build/run.py
@@ -65,9 +65,9 @@ class BuildPlan:
         """
         Execute build plan using the local strategy. Files from the build plan are placed in
         the build root directory ``root``, and, if ``run_script`` is ``True``, the script
-        appropriate for the platform (``{script}.bat`` on Windows, ``{script}.sh`` elsewhere) is
-        executed in the build root. If ``env`` is not ``None``, the environment is extended
-        (not replaced) with ``env``.
+        appropriate for the platform (``{script}.bat`` on Windows, ``{script}.sh`` elsewhere)
+        is executed in the build root. If ``env`` is not ``None``, the environment is replaced
+        with ``env``.
 
         Returns :class:`LocalBuildProducts`.
         """
@@ -91,18 +91,15 @@ class BuildPlan:
                     f.write(content)
 
             if run_script:
-                script_env = dict(os.environ)
-                if env is not None:
-                    script_env.update(env)
                 if sys.platform.startswith("win32"):
                     # Without "call", "cmd /c {}.bat" will return 0.
                     # See https://stackoverflow.com/a/30736987 for a detailed explanation of why.
                     # Running the script manually from a command prompt is unaffected.
                     subprocess.check_call(["cmd", "/c", "call {}.bat".format(self.script)],
-                                          env=script_env)
+                                          env=os.environ if env is None else env)
                 else:
                     subprocess.check_call(["sh", "{}.sh".format(self.script)],
-                                          env=script_env)
+                                          env=os.environ if env is None else env)
 
             return LocalBuildProducts(os.getcwd())
 


### PR DESCRIPTION
If it adds to the environment then it ultimately creates the same kind of problem it was intended to solve--a need to reproduce the calls to `subprocess` in the code outside. It's not that hard to merge two dicts, plus much of the time enough you can get by with having just `PATH` and `AMARANTH_ENV_*` (if even that).

If an override is wanted it can be done easily enough with:

    .execute_local(env={**os.environ, "VAR": "VALUE"})