### PR TITLE
lib.wiring: fix equality of `FlippedSignature` with other object

### DIFF
--- a/amaranth/lib/wiring.py
+++ b/amaranth/lib/wiring.py
@@ -760,7 +760,7 @@ class Component(Elaboratable):
             for name, annot in getattr(base, "__annotations__", {}).items():
                 if name.startswith("_"):
                     continue
-                if (annot in (Value, Signal, Const) or
+                if (annot is Value or annot is Signal or annot is Const or
                         (isinstance(annot, type) and issubclass(annot, ValueCastable)) or
                         isinstance(annot, Signature)):
                     if isinstance(annot, type):

--- a/amaranth/lib/wiring.py
+++ b/amaranth/lib/wiring.py
@@ -484,9 +484,11 @@ class FlippedSignature:
             return self.flip() == other.flip()
         else:
             # Delegate comparisons back to Signature (or its descendant) by flipping the arguments;
-            # equality must be reflexive but the implementation of __eq__ need not be, and we can
-            # take advantage of it here.
-            return other == self
+            # equality must be reflexive but the implementation of `__eq__` need not be, and we can
+            # take advantage of it here. This is done by returning `NotImplemented`, otherwise if
+            # the other object cannot be compared to a `FlippedSignature` either this will result
+            # in infinite recursion.
+            return NotImplemented
 
     # These methods do not access instance variables and so their implementation can be shared
     # between the normal and the flipped member collections.

--- a/tests/test_lib_wiring.py
+++ b/tests/test_lib_wiring.py
@@ -832,3 +832,15 @@ class ComponentTestCase(unittest.TestCase):
                 r"a signature member; did you mean 'val2: In\(MockValueCastable\)' or "
                 r"'val2: Out\(MockValueCastable\)'\?$"):
             C3().signature
+
+    def test_bug_882(self):
+        class PageBuffer(Component):
+            rand: Signature({}).flip()
+            other: Out(1)
+
+        with self.assertWarnsRegex(SyntaxWarning,
+                r"^Component '.+\.PageBuffer' has an annotation 'rand: Signature\({}\)\.flip\(\)', "
+                r"which is not a signature member; did you mean "
+                r"'rand: In\(Signature\({}\)\.flip\(\)\)' or "
+                r"'rand: Out\(Signature\({}\)\.flip\(\)\)'\?$"):
+            PageBuffer()


### PR DESCRIPTION
Fixes #882.