### PR TITLE
vendor/*: add missing `__all__`

### DIFF
--- a/amaranth/vendor/gowin.py
+++ b/amaranth/vendor/gowin.py
@@ -5,8 +5,11 @@ import importlib
 from .. import vendor
 
 
+__all__ = ["GowinPlatform"]
+
+
 def __getattr__(name):
-    if name in ("GowinPlatform",):
+    if name in __all__:
         warnings.warn(f"instead of `{__name__}.{name}`, use `amaranth.vendor.{name}",
                       DeprecationWarning, stacklevel=2)
         return getattr(vendor, name)

--- a/amaranth/vendor/intel.py
+++ b/amaranth/vendor/intel.py
@@ -5,8 +5,11 @@ import importlib
 from .. import vendor
 
 
+__all__ = ["IntelPlatform"]
+
+
 def __getattr__(name):
-    if name in ("IntelPlatform",):
+    if name in __all__:
         warnings.warn(f"instead of `{__name__}.{name}`, use `amaranth.vendor.{name}",
                       DeprecationWarning, stacklevel=2)
         return getattr(vendor, name)

--- a/amaranth/vendor/lattice_ecp5.py
+++ b/amaranth/vendor/lattice_ecp5.py
@@ -5,8 +5,11 @@ import importlib
 from .. import vendor
 
 
+__all__ = ["LatticeECP5Platform"]
+
+
 def __getattr__(name):
-    if name in ("LatticeECP5Platform",):
+    if name in __all__:
         warnings.warn(f"instead of `{__name__}.{name}`, use `amaranth.vendor.{name}",
                       DeprecationWarning, stacklevel=2)
         return getattr(vendor, name)

--- a/amaranth/vendor/lattice_ice40.py
+++ b/amaranth/vendor/lattice_ice40.py
@@ -5,8 +5,11 @@ import importlib
 from .. import vendor
 
 
+__all__ = ["LatticeICE40Platform"]
+
+
 def __getattr__(name):
-    if name in ("LatticeICE40Platform",):
+    if name in __all__:
         warnings.warn(f"instead of `{__name__}.{name}`, use `amaranth.vendor.{name}",
                       DeprecationWarning, stacklevel=2)
         return getattr(vendor, name)

--- a/amaranth/vendor/lattice_machxo_2_3l.py
+++ b/amaranth/vendor/lattice_machxo_2_3l.py
@@ -5,8 +5,11 @@ import importlib
 from .. import vendor
 
 
+__all__ = ["LatticeMachXO2Platform", "LatticeMachXO3LPlatform"]
+
+
 def __getattr__(name):
-    if name in ("LatticeMachXO2Platform", "LatticeMachXO3LPlatform"):
+    if name in __all__:
         warnings.warn(f"instead of `{__name__}.{name}`, use `amaranth.vendor.{name}",
                       DeprecationWarning, stacklevel=2)
         return getattr(vendor, name)

--- a/amaranth/vendor/quicklogic.py
+++ b/amaranth/vendor/quicklogic.py
@@ -5,8 +5,11 @@ import importlib
 from .. import vendor
 
 
+__all__ = ["QuicklogicPlatform"]
+
+
 def __getattr__(name):
-    if name in ("QuicklogicPlatform",):
+    if name in __all__:
         warnings.warn(f"instead of `{__name__}.{name}`, use `amaranth.vendor.{name}",
                       DeprecationWarning, stacklevel=2)
         return getattr(vendor, name)

--- a/amaranth/vendor/xilinx.py
+++ b/amaranth/vendor/xilinx.py
@@ -5,8 +5,11 @@ import importlib
 from .. import vendor
 
 
+__all__ = ["XilinxPlatform"]
+
+
 def __getattr__(name):
-    if name in ("XilinxPlatform",):
+    if name in __all__:
         warnings.warn(f"instead of `{__name__}.{name}`, use `amaranth.vendor.{name}",
                       DeprecationWarning, stacklevel=2)
         return getattr(vendor, name)


### PR DESCRIPTION
This broke code that did e.g.

    from amaranth.vendor.xilinx import *

which is common in amaranth-boards.