### PR TITLE
vendor._lattice_ice40: add an icepack_opts override

### DIFF
--- a/amaranth/vendor/_lattice_ice40.py
+++ b/amaranth/vendor/_lattice_ice40.py
@@ -160,6 +160,7 @@ class LatticeICE40Platform(TemplatedPlatform):
         r"""
         {{invoke_tool("icepack")}}
             {{verbose("-v")}}
+            {{get_override("icepack_opts")|options}}
             {{name}}.asc
             {{name}}.bin
         """

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -125,6 +125,7 @@ Platform integration changes
 
 .. currentmodule:: amaranth.vendor
 
+* Added: ``icepack_opts`` override in :class:`vendor.LatticeICE40Platform`.
 * Added: ``OSCH`` as ``default_clk`` clock source in :class:`vendor.LatticeMachXO2Platform`, :class:`vendor.LatticeMachXO3LPlatform`.
 * Added: Xray toolchain support in :class:`vendor.XilinxPlatform`.
 * Added: :class:`vendor.GowinPlatform`.


### PR DESCRIPTION
Add an icepack_opts override in case the user wants to pass  extra options to icepack as part of the build process. For example can be used to pass the "-s" option to disable putting the SPI flash to sleep after the FPGA is configured.