### PR TITLE
back.rtlil: put hierarchy in module name instead of an attribute

### DIFF
--- a/amaranth/back/rtlil.py
+++ b/amaranth/back/rtlil.py
@@ -820,11 +820,10 @@ def _convert_fragment(builder, fragment, name_map, hierarchy):
         else:
             return "\\{}".format(fragment.type), port_map
 
-    module_name  = hierarchy[-1] or "anonymous"
+    module_name  = ".".join(name or "anonymous" for name in hierarchy)
     module_attrs = OrderedDict()
     if len(hierarchy) == 1:
         module_attrs["top"] = 1
-    module_attrs["amaranth.hierarchy"] = ".".join(name or "anonymous" for name in hierarchy)
 
     with builder.module(module_name, attrs=module_attrs) as module:
         compiler_state = _ValueCompilerState(module)


### PR DESCRIPTION
The attribute sees essentially no use and the information is much better served by putting it in the module name. In addition this means that the entire tree can be renamed simply by renaming the top module.

Tools like GTKWave show the names of the instances, not the modules, so they are not affected by the longer names.