### PR TITLE
Elaboratable does not need ABCMeta as its metaclass

### DIFF
--- a/amaranth/hdl/ir.py
+++ b/amaranth/hdl/ir.py
@@ -20,7 +20,7 @@ class UnusedElaboratable(UnusedMustUse):
     _MustUse__silence = True
 
 
-class Elaboratable(MustUse, metaclass=ABCMeta):
+class Elaboratable(MustUse):
     _MustUse__warning = UnusedElaboratable
 
 


### PR DESCRIPTION
This was introduced in commit 44711b7d, and was never used within Amaranth itself. While technically a breaking change I think this will not cause enough breakage to warrant a deprecation cycle (nor can we make this a deprecation this without a lot of work).