### PR TITLE
Miscellaneous fixes, mostly found via pylance

### DIFF
--- a/amaranth/hdl/ast.py
+++ b/amaranth/hdl/ast.py
@@ -604,7 +604,7 @@ class Value(metaclass=ABCMeta):
 
     @abstractmethod
     def _rhs_signals(self):
-        pass # :nocov:
+        raise NotImplementedError # :nocov:
 
 
 @final

--- a/amaranth/vendor/_gowin.py
+++ b/amaranth/vendor/_gowin.py
@@ -596,7 +596,7 @@ class GowinPlatform(TemplatedPlatform):
             )
         return m
 
-    def get_diff_input_output(self, pin, port, atttr, invert):
+    def get_diff_input_output(self, pin, port, attrs, invert):
         self._check_feature("differential input/output", pin, attrs,
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()

--- a/docs/_code/led_blinker.py
+++ b/docs/_code/led_blinker.py
@@ -18,7 +18,7 @@ class LEDBlinker(Elaboratable):
 
         return m
 # --- BUILD ---
-from amaranth_boards.icestick import *
+from amaranth_boards.icestick import ICEStickPlatform
 
 
 ICEStickPlatform().build(LEDBlinker(), do_program=True)

--- a/examples/board/01_blinky.py
+++ b/examples/board/01_blinky.py
@@ -2,7 +2,7 @@
 # using the platform default clock (and default reset, if any).
 
 from amaranth import *
-from amaranth_boards.ice40_hx1k_blink_evn import *
+from amaranth_boards.ice40_hx1k_blink_evn import ICE40HX1KBlinkEVNPlatform
 
 
 class Blinky(Elaboratable):

--- a/examples/board/02_domain.py
+++ b/examples/board/02_domain.py
@@ -3,7 +3,7 @@
 # independently created in addition to the main "sync" domain.
 
 from amaranth import *
-from amaranth_boards.ice40_hx1k_blink_evn import *
+from amaranth_boards.ice40_hx1k_blink_evn import ICE40HX1KBlinkEVNPlatform
 
 
 class BlinkyWithDomain(Elaboratable):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ docs = [
   "sphinx-rtd-theme~=1.2",
   "sphinx-autobuild",
 ]
+examples = [
+  "amaranth-boards @ git+https://github.com/amaranth-lang/amaranth-boards.git"
+]
 
 [tool.pdm.scripts]
 test.composite = ["test-code", "test-docs"]


### PR DESCRIPTION
Only the typo in `vendor._gowin` has a semantic difference. (It's a bugfix.)