### PR TITLE
lib.wiring: Component.signature should not be a class method

### DIFF
--- a/amaranth/lib/wiring.py
+++ b/amaranth/lib/wiring.py
@@ -779,9 +779,6 @@ class Component(Elaboratable):
                                 f"because an attribute with the same name already exists")
         self.__dict__.update(self.signature.members.create())
 
-    # TODO(py3.9): This should be a class method, but descriptors don't stack this way
-    # in Python 3.8 and below.
-    # @classmethod
     @property
     def signature(self):
         cls = type(self)


### PR DESCRIPTION
While the capability of providing signatures for components that are not parametric is useful, most Amaranth gateware is heavily parameterized, and the capability is not worth making most subclasses Liskov-incompatible with the base class (where the derived class would not provide `signature` as a class method anymore).