### PR TITLE
lib.wiring: Remove superfluous method alias

### DIFF
--- a/amaranth/lib/wiring.py
+++ b/amaranth/lib/wiring.py
@@ -522,7 +522,6 @@ class FlippedSignature:
     frozen = Signature.frozen
     freeze = Signature.freeze
     is_compliant = Signature.is_compliant
-    create = Signature.create
 
     # FIXME: document this logic
     def __getattr__(self, name):


### PR DESCRIPTION
I believe you missed removing the alias to `Signature.create`. It's no longer needed after #915.