### PR TITLE
hdl.mem: fix transparent read handling for simple write ports.

### DIFF
--- a/amaranth/hdl/mem.py
+++ b/amaranth/hdl/mem.py
@@ -187,7 +187,8 @@ class Memory(Elaboratable):
                                 parts.append(Mux(cond, write_port.data[bits], data[bits]))
                             data = Cat(parts)
                         else:
-                            data = Mux(write_port.en, write_port.data, data)
+                            cond = write_port.en & (port.addr == write_port.addr)
+                            data = Mux(cond, write_port.data, data)
                 f.add_statements(
                     Switch(port.en, {
                         1: port.data.eq(data)

--- a/tests/test_sim.py
+++ b/tests/test_sim.py
@@ -815,7 +815,52 @@ class SimulatorIntegrationTestCase(FHDLTestCase):
             sim.add_clock(1e-6)
             sim.add_sync_process(process)
 
-    def test_memory_transparency(self):
+    def test_memory_transparency_simple(self):
+        m = Module()
+        init = [0x11, 0x22, 0x33, 0x44]
+        m.submodules.memory = memory = Memory(width=8, depth=4, init=init)
+        rdport = memory.read_port()
+        wrport = memory.write_port(granularity=8)
+        with self.assertSimulation(m) as sim:
+            def process():
+                yield rdport.addr.eq(0)
+                yield
+                yield Settle()
+                self.assertEqual((yield rdport.data), 0x11)
+                yield rdport.addr.eq(1)
+                yield
+                yield Settle()
+                self.assertEqual((yield rdport.data), 0x22)
+                yield wrport.addr.eq(0)
+                yield wrport.data.eq(0x44444444)
+                yield wrport.en.eq(1)
+                yield
+                yield Settle()
+                self.assertEqual((yield rdport.data), 0x22)
+                yield wrport.addr.eq(1)
+                yield wrport.data.eq(0x55)
+                yield wrport.en.eq(1)
+                yield
+                yield Settle()
+                self.assertEqual((yield rdport.data), 0x55)
+                yield wrport.addr.eq(1)
+                yield wrport.data.eq(0x66)
+                yield wrport.en.eq(1)
+                yield rdport.en.eq(0)
+                yield
+                yield Settle()
+                self.assertEqual((yield rdport.data), 0x55)
+                yield wrport.addr.eq(2)
+                yield wrport.data.eq(0x77)
+                yield wrport.en.eq(1)
+                yield rdport.en.eq(1)
+                yield
+                yield Settle()
+                self.assertEqual((yield rdport.data), 0x66)
+            sim.add_clock(1e-6)
+            sim.add_sync_process(process)
+
+    def test_memory_transparency_multibit(self):
         m = Module()
         init = [0x11111111, 0x22222222, 0x33333333, 0x44444444]
         m.submodules.memory = memory = Memory(width=32, depth=4, init=init)


### PR DESCRIPTION
Fixes #922.