### PR TITLE
lib.wiring: fix `Component.signature` on subclasses without annotations.

### DIFF
--- a/amaranth/lib/wiring.py
+++ b/amaranth/lib/wiring.py
@@ -786,7 +786,7 @@ class Component(Elaboratable):
         cls = type(self)
         signature = Signature({})
         for base in cls.mro()[:cls.mro().index(Component)]:
-            for name, annot in getattr(base, "__annotations__", {}).items():
+            for name, annot in base.__dict__.get("__annotations__", {}).items():
                 if name.startswith("_"):
                     continue
                 if (annot is Value or annot is Signal or annot is Const or

--- a/tests/test_lib_wiring.py
+++ b/tests/test_lib_wiring.py
@@ -887,3 +887,16 @@ class ComponentTestCase(unittest.TestCase):
                 r"'rand: In\(Signature\({}\)\.flip\(\)\)' or "
                 r"'rand: Out\(Signature\({}\)\.flip\(\)\)'\?$"):
             PageBuffer()
+
+    def test_inherit(self):
+        class A(Component):
+            clk: In(1)
+
+        class B(A):
+            rst: In(1)
+
+        class C(B):
+            pass
+
+        c = C()
+        self.assertEqual(c.signature, Signature({"clk": In(1), "rst": In(1)}))


### PR DESCRIPTION
On Python <3.10, classes without annotations do not get an `__annotations__` member at all, so the `getattr` on a subclass falls back to the parent class `__annotations__`, attempting to create signature members twice.  Fix that by looking at the `__dict__` instead.