### PR TITLE
lib.io: `Pin.oe` should have `Flow.Out`

### DIFF
--- a/amaranth/lib/io.py
+++ b/amaranth/lib/io.py
@@ -43,7 +43,7 @@ def _pin_signature(width, dir, xdr=0):
             for n in range(xdr):
                 members["o{}".format(n)] = Out(width)
     if dir in ("oe", "io"):
-        members["oe"] = In(1)
+        members["oe"] = Out(1)
     return Signature(members)
 
 


### PR DESCRIPTION
I expected `Pin.o` and `Pin.oe` to have identical flow.