### PR TITLE
CI: adjust the `required` job to never be skipped

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -83,14 +83,14 @@ jobs:
           name: docs
           path: docs/_build
 
-  required: # group all required workflows into one for the required status check
+  required: # group all required workflows into one to avoid reconfiguring this in Actions settings
     needs:
       - test
       - document
+    if: always() && !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          true
+      - run: ${{ contains(needs.*.result, 'failure') && 'false' || 'true' }}
 
   publish-docs:
     needs: document


### PR DESCRIPTION
While this fails a normal required status check, the merge group will succeed even if a required status check is skipped.