### PR TITLE
(Merge after 0.4 is released) Remove non-FWFT FIFOs

### DIFF
--- a/amaranth/lib/fifo.py
+++ b/amaranth/lib/fifo.py
@@ -55,31 +55,21 @@ class FIFOInterface:
     read at the output interface (``r_data``, ``r_rdy``, ``r_en``). The data entry written first
     to the input also appears first on the output.
     """,
-    parameters="""
-    fwft : bool
-        First-word fallthrough. If set, when ``r_rdy`` rises, the first entry is already
-        available, i.e. ``r_data`` is valid. Otherwise, after ``r_rdy`` rises, it is necessary
-        to strobe ``r_en`` for ``r_data`` to become valid.
-    """.strip(),
+    parameters="",
     r_data_valid="The conditions in which ``r_data`` is valid depends on the type of the queue.",
     attributes="",
     w_attributes="",
     r_attributes="")
 
-    def __init__(self, *, width, depth, fwft=True):
+    def __init__(self, *, width, depth):
         if not isinstance(width, int) or width < 0:
             raise TypeError("FIFO width must be a non-negative integer, not {!r}"
                             .format(width))
         if not isinstance(depth, int) or depth < 0:
             raise TypeError("FIFO depth must be a non-negative integer, not {!r}"
                             .format(depth))
-        if not fwft:
-            warnings.warn("support for FIFOs with `fwft=False` will be removed without a replacement; "
-                          "consider switching to `fwft=True` or copy the module into your project to continue using it",
-                          DeprecationWarning)
         self.width = width
         self.depth = depth
-        self.fwft  = fwft
 
         self.w_data = Signal(width, reset_less=True)
         self.w_rdy  = Signal() # writable; not full
@@ -107,14 +97,8 @@ class SyncFIFO(Elaboratable, FIFOInterface):
     Read and write interfaces are accessed from the same clock domain. If different clock domains
     are needed, use :class:`AsyncFIFO`.
     """.strip(),
-    parameters="""
-    fwft : bool
-        First-word fallthrough. If set, when the queue is empty and an entry is written into it,
-        that entry becomes available on the output on the same clock cycle. Otherwise, it is
-        necessary to assert ``r_en`` for ``r_data`` to become valid.
-    """.strip(),
-    r_data_valid="For FWFT queues, valid if ``r_rdy`` is asserted. "
-                 "For non-FWFT queues, valid on the next cycle after ``r_rdy`` and ``r_en`` have been asserted.",
+    parameters="",
+    r_data_valid="Valid if ``r_rdy`` is asserted.",
     attributes="""
     level : Signal(range(depth + 1)), out
         Number of unread entries. This level is the same between read and write for synchronous FIFOs.
@@ -122,14 +106,8 @@ class SyncFIFO(Elaboratable, FIFOInterface):
     r_attributes="",
     w_attributes="")
 
-    def __init__(self, *, width, depth, fwft=True):
-        if not fwft:
-            warnings.warn("support for FIFOs with `fwft=False` will be removed without a replacement; "
-                          "consider switching to `fwft=True` or copy the module into your project to continue using it",
-                          DeprecationWarning)
+    def __init__(self, *, width, depth):
         super().__init__(width=width, depth=depth)
-        # Fix up fwft after initialization to avoid the warning from FIFOInterface.
-        self.fwft = fwft
 
         self.level = Signal(range(depth + 1))
 
@@ -154,8 +132,7 @@ class SyncFIFO(Elaboratable, FIFOInterface):
 
         storage = Memory(width=self.width, depth=self.depth)
         w_port  = m.submodules.w_port = storage.write_port()
-        r_port  = m.submodules.r_port = storage.read_port(
-            domain="comb" if self.fwft else "sync", transparent=self.fwft)
+        r_port  = m.submodules.r_port = storage.read_port(domain="comb")
         produce = Signal(range(self.depth))
         consume = Signal(range(self.depth))
 
@@ -171,8 +148,6 @@ class SyncFIFO(Elaboratable, FIFOInterface):
             r_port.addr.eq(consume),
             self.r_data.eq(r_port.data),
         ]
-        if not self.fwft:
-            m.d.comb += r_port.en.eq(self.r_en)
         with m.If(do_read):
             m.d.sync += consume.eq(_incr(consume, self.depth))
 
@@ -214,16 +189,13 @@ class SyncFIFOBuffered(Elaboratable, FIFOInterface):
     description="""
     Buffered synchronous first in, first out queue.
 
-    This queue's interface is identical to :class:`SyncFIFO` configured as ``fwft=True``, but it
+    This queue's interface is identical to :class:`SyncFIFO`, but it
     does not use asynchronous memory reads, which are incompatible with FPGA block RAMs.
 
     In exchange, the latency between an entry being written to an empty queue and that entry
     becoming available on the output is increased by one cycle compared to :class:`SyncFIFO`.
     """.strip(),
-    parameters="""
-    fwft : bool
-        Always set.
-    """.strip(),
+    parameters="",
     attributes="""
     level : Signal(range(depth + 1)), out
         Number of unread entries. This level is the same between read and write for synchronous FIFOs.
@@ -369,8 +341,6 @@ class AsyncFIFO(Elaboratable, FIFOInterface):
         Read clock domain.
     w_domain : str
         Write clock domain.
-    fwft : bool
-        Always set.
     """.strip(),
     attributes="",
     r_data_valid="Valid if ``r_rdy`` is asserted.",
@@ -548,8 +518,6 @@ class AsyncFIFOBuffered(Elaboratable, FIFOInterface):
         Read clock domain.
     w_domain : str
         Write clock domain.
-    fwft : bool
-        Always set.
     """.strip(),
     attributes="",
     r_data_valid="Valid if ``r_rdy`` is asserted.",

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -25,6 +25,8 @@ Standard library changes
 .. currentmodule:: amaranth.lib
 
 * Removed: (deprecated in 0.4) :mod:`amaranth.lib.scheduler`. (`RFC 19`_)
+* Removed: (deprecated in 0.4) :class:`amaranth.lib.fifo.FIFOInterface` with ``fwft=False``. (`RFC 20`_)
+* Removed: (deprecated in 0.4) :class:`amaranth.lib.fifo.SyncFIFO` with ``fwft=False``. (`RFC 20`_)
 
 
 Version 0.4

--- a/docs/stdlib/fifo.rst
+++ b/docs/stdlib/fifo.rst
@@ -12,7 +12,7 @@ The ``amaranth.lib.fifo`` module provides building blocks for first-in, first-ou
 
       The :class:`FIFOInterface` class can be used directly to substitute a FIFO in tests, or inherited from in a custom FIFO implementation.
 
-.. autoclass:: SyncFIFO(*, width, depth, fwft=True)
+.. autoclass:: SyncFIFO(*, width, depth)
 .. autoclass:: SyncFIFOBuffered(*, width, depth)
 .. autoclass:: AsyncFIFO(*, width, depth, r_domain="read", w_domain="write", exact_depth=False)
 .. autoclass:: AsyncFIFOBuffered(*, width, depth, r_domain="read", w_domain="write", exact_depth=False)


### PR DESCRIPTION
Fixes #875.

Note: this depends on #840 and will fail tests without it.