### PR TITLE
(Merge after 0.4 is released) Remove `Const.normalize`

### DIFF
--- a/amaranth/hdl/ast.py
+++ b/amaranth/hdl/ast.py
@@ -711,16 +711,6 @@ class Const(Value):
     """
     src_loc = None
 
-    # TODO(amaranth-0.5): remove
-    @staticmethod
-    @deprecated("instead of `Const.normalize(value, shape)`, use `Const(value, shape).value`")
-    def normalize(value, shape):
-        mask = (1 << shape.width) - 1
-        value &= mask
-        if shape.signed and value >> (shape.width - 1):
-            value |= ~mask
-        return value
-
     @staticmethod
     def cast(obj):
         """Converts ``obj`` to an Amaranth constant.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,17 @@ Changelog
 This document describes changes to the public interfaces in the Amaranth language and standard library. It does not include most bug fixes or implementation changes.
 
 
+Version 0.5 (unreleased)
+========================
+
+Language changes
+----------------
+
+.. currentmodule:: amaranth.hdl
+
+* Removed: (deprecated in 0.4) :meth:`Const.normalize`. (`RFC 5`_)
+
+
 Version 0.4
 ===========
 


### PR DESCRIPTION
Closes #754.