### PR TITLE
lib.data: implement `__eq__`, `__ne__`, `__repr__` for `View`.

### DIFF
--- a/amaranth/lib/data.py
+++ b/amaranth/lib/data.py
@@ -592,7 +592,7 @@ class View(ValueCastable):
                 warnings.warn("View layout includes a field {!r} that will be shadowed by "
                               "the view attribute '{}.{}.{}'"
                               .format(name, type(self).__module__, type(self).__qualname__, name),
-                              SyntaxWarning, stacklevel=1)
+                              SyntaxWarning, stacklevel=2)
         self.__orig_layout = layout
         self.__layout = cast_layout
         self.__target = cast_target
@@ -714,6 +714,35 @@ class View(ValueCastable):
                                  "accessed by indexing"
                                  .format(self.__target, name))
         return item
+
+    def __eq__(self, other):
+        if isinstance(other, View):
+            if self.__layout.size != other.__layout.size:
+                raise TypeError(f"View of {self.__layout!r} can only be compared to a value of the same width, not {other!r}")
+            if self.__layout != other.__layout:
+                warnings.warn(f"View of {self.__layout!r} compared to a view of {other.__layout!r}",
+                              SyntaxWarning, stacklevel=2)
+            return self.__target == other.__target
+        other = Value.cast(other)
+        if self.__layout.size != other.shape().width:
+            raise TypeError(f"View of {self.__layout!r} can only be compared to a value of the same width, not {other!r}")
+        return self.__target == other
+
+    def __ne__(self, other):
+        if isinstance(other, View):
+            if self.__layout.size != other.__layout.size:
+                raise TypeError(f"View of {self.__layout!r} can only be compared to a value of the same width, not {other!r}")
+            if self.__layout != other.__layout:
+                warnings.warn(f"View of {self.__layout!r} compared to a view of {other.__layout!r}",
+                              SyntaxWarning, stacklevel=2)
+            return self.__target != other.__target
+        other = Value.cast(other)
+        if self.__layout.size != other.shape().width:
+            raise TypeError(f"View of {self.__layout!r} can only be compared to a value of the same width, not {other!r}")
+        return self.__target != other
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self.__layout!r}, {self.__target!r})"
 
 
 class _AggregateMeta(ShapeCastable, type):

--- a/tests/test_lib_data.py
+++ b/tests/test_lib_data.py
@@ -632,6 +632,38 @@ class ViewTestCase(FHDLTestCase):
                 r"^View of \(sig \$signal\) with an array layout does not have fields$"):
             Signal(ArrayLayout(unsigned(1), 1), reset=[0]).reset
 
+    def test_eq(self):
+        s1 = Signal(StructLayout({"a": unsigned(2)}))
+        s2 = Signal(StructLayout({"a": unsigned(2)}))
+        s3 = Signal(StructLayout({"a": unsigned(1), "b": unsigned(1)}))
+        s4 = Signal(StructLayout({"a": unsigned(1)}))
+        self.assertRepr(s1 == s2, "(== (sig s1) (sig s2))")
+        self.assertRepr(s1 != s2, "(!= (sig s1) (sig s2))")
+        self.assertRepr(s1 == Const(0, 2), "(== (sig s1) (const 2'd0))")
+        self.assertRepr(s1 != Const(0, 2), "(!= (sig s1) (const 2'd0))")
+        with self.assertWarnsRegex(SyntaxWarning,
+                r"^View of .* compared to a view of .*$"):
+            self.assertRepr(s1 == s3, "(== (sig s1) (sig s3))")
+        with self.assertWarnsRegex(SyntaxWarning,
+                r"^View of .* compared to a view of .*$"):
+            self.assertRepr(s1 != s3, "(!= (sig s1) (sig s3))")
+        with self.assertRaisesRegex(TypeError,
+                r"^View of .* can only be compared to a value of the same width, not .*$"):
+            s1 == s4
+        with self.assertRaisesRegex(TypeError,
+                r"^View of .* can only be compared to a value of the same width, not .*$"):
+            s1 != s4
+        with self.assertRaisesRegex(TypeError,
+                r"^View of .* can only be compared to a value of the same width, not .*$"):
+            s1 == Const(0, 1)
+        with self.assertRaisesRegex(TypeError,
+                r"^View of .* can only be compared to a value of the same width, not .*$"):
+            s1 != Const(0, 1)
+
+    def test_repr(self):
+        s1 = Signal(StructLayout({"a": unsigned(2)}))
+        self.assertRepr(s1, "View(StructLayout({'a': unsigned(2)}), (sig s1))")
+
 
 class StructTestCase(FHDLTestCase):
     def test_construct(self):


### PR DESCRIPTION
There is also an alternate version of this PR for discussion purposes: #966.