### PR TITLE
Add support for dumping structure fields in VCD

### DIFF
--- a/amaranth/hdl/_repr.py
+++ b/amaranth/hdl/_repr.py
@@ -1,0 +1,46 @@
+from abc import ABCMeta, abstractmethod
+
+
+__all__ = ["Format", "FormatInt", "FormatEnum", "FormatCustom", "Repr"]
+
+
+class Format(metaclass=ABCMeta):
+    @abstractmethod
+    def format(self, value):
+        raise NotImplementedError
+
+
+class FormatInt(Format):
+    def format(self, value):
+        return f"{value:d}"
+
+
+class FormatEnum(Format):
+    def __init__(self, enum):
+        self.enum = enum
+
+    def format(self, value):
+        try:
+            return f"{self.enum(value).name}/{value:d}"
+        except ValueError:
+            return f"?/{value:d}"
+
+
+class FormatCustom(Format):
+    def __init__(self, formatter):
+        self.formatter = formatter
+
+    def format(self, value):
+        return self.formatter(value)
+
+
+class Repr:
+    def __init__(self, format, value, *, path=()):
+        from .ast import Value # avoid a circular dependency
+        assert isinstance(format, Format)
+        assert isinstance(value, Value)
+        assert isinstance(path, tuple) and all(isinstance(part, (str, int)) for part in path)
+
+        self.format = format
+        self.value  = value
+        self.path   = path

--- a/amaranth/lib/enum.py
+++ b/amaranth/lib/enum.py
@@ -2,6 +2,7 @@ import enum as py_enum
 import warnings
 
 from ..hdl.ast import Value, Shape, ShapeCastable, Const
+from ..hdl._repr import *
 
 
 __all__ = py_enum.__all__
@@ -149,6 +150,9 @@ class EnumMeta(ShapeCastable, py_enum.EnumMeta):
         else:
             member = cls(init)
         return Const(member.value, cls.as_shape())
+
+    def _value_repr(cls, value):
+        yield Repr(FormatEnum(cls), value)
 
 
 class Enum(py_enum.Enum):


### PR DESCRIPTION
See #790.

This PR adds an entirely private API for describing formatting of values that is used in the standard library, in departure from our standing policy of not using private APIs in the standard library.

This is a temporary measure intended to get the version 0.4 released faster, as it has been years in the making. It is expected that this API will be made public in the version 0.5 after going through the usual RFC process.

This PR only adds VCD lines for fields defined in `lib.data.Layout` when using `sim.pysim`. The emitted RTLIL and Verilog remain the same. It is expected that when `sim.cxxsim` lands, RTLIL/Verilog output will include aliases for layout fields as well.

The value representation API also handles formatting of enumerations, with no changes visible to the designer. The implementation of `Signal(decoder=)` is changed as well to use the new API, with full backwards compatibility and no public API changes.