### PR TITLE
lib.io: fix Pin.eq to work when FlippedInterface is involved.

### DIFF
--- a/amaranth/lib/io.py
+++ b/amaranth/lib/io.py
@@ -4,7 +4,7 @@ from .. import *
 with warnings.catch_warnings():
     warnings.filterwarnings(action="ignore", category=DeprecationWarning)
     from ..hdl.rec import *
-from ..lib.wiring import In, Out, Signature
+from ..lib.wiring import In, Out, Signature, flipped, FlippedInterface
 
 
 __all__ = ["pin_layout", "Pin"]
@@ -135,4 +135,7 @@ class Pin(Record):
         first_field, _, _ = next(iter(Pin(1, dir="o").layout))
         warnings.warn(f"`pin.eq(...)` is deprecated; use `pin.{first_field}.eq(...)` here",
                       DeprecationWarning, stacklevel=2)
-        return super().eq(other)
+        if isinstance(self, FlippedInterface):
+            return Record.eq(flipped(self), other)
+        else:
+            return Record.eq(self, other)

--- a/tests/test_build_res.py
+++ b/tests/test_build_res.py
@@ -315,3 +315,12 @@ class ResourceManagerTestCase(FHDLTestCase):
                 (r"^Cannot add clock constraint on \(sig clk100_0__i\), which is already "
                     r"constrained to 100000000\.0 Hz$")):
             self.cm.add_clock_constraint(clk100.i, 1e6)
+
+    def test_eq_deprecation(self):
+        user_led = self.cm.request("user_led", 0)
+        m = Module()
+        with self.assertWarns(DeprecationWarning):
+            m.d.sync += user_led.eq(1)
+        p = Pin(4, "o")
+        with self.assertWarns(DeprecationWarning):
+            m.d.sync += p.eq(1)


### PR DESCRIPTION
This was broken by #915, when platform started handing out `FlippedInterface` versions of `Pin`.