### PR TITLE
Admit non-signals in `Simulator.write_vcd(traces=...)`

### DIFF
--- a/amaranth/sim/pysim.py
+++ b/amaranth/sim/pysim.py
@@ -64,9 +64,10 @@ class _VCDWriter:
 
         trace_names = SignalDict()
         for trace in traces:
-            if trace not in signal_names:
-                trace_names[trace] = {("bench", trace.name)}
-            self.traces.append(trace)
+            for trace_signal in trace._rhs_signals():
+                if trace_signal not in signal_names:
+                    trace_names[trace_signal] = {("bench", trace_signal.name)}
+                self.traces.append(trace_signal)
 
         if self.vcd_writer is None:
             return


### PR DESCRIPTION
Rather than requiring each additional requested trace to be a signal, all of the signals in the provided value are added to the GTKW file and to the VCD file if they are not already there. This improves usability for `lib.data` as struct fields can now be added to traces.