### PR TITLE
Implement RFC 34: Rename `amaranth.lib.wiring.Interface` to `PureInterface`.

### DIFF
--- a/amaranth/lib/wiring.py
+++ b/amaranth/lib/wiring.py
@@ -10,7 +10,7 @@ from ..hdl.ir import Elaboratable
 from .._utils import final
 
 
-__all__ = ["In", "Out", "Signature", "Interface", "connect", "flipped", "Component"]
+__all__ = ["In", "Out", "Signature", "PureInterface", "connect", "flipped", "Component"]
 
 
 class Flow(enum.Enum):
@@ -504,7 +504,7 @@ class Signature(metaclass=SignatureMeta):
         return result
 
     def create(self, *, path=()):
-        return Interface(self, path=path)
+        return PureInterface(self, path=path)
 
     def __repr__(self):
         if type(self) is Signature:
@@ -600,7 +600,7 @@ class FlippedSignature:
         return f"{self.__unflipped!r}.flip()"
 
 
-class Interface:
+class PureInterface:
     def __init__(self, signature, *, path):
         self.__dict__.update({
             "signature": signature,
@@ -611,7 +611,7 @@ class Interface:
         attrs = ''.join(f", {name}={value!r}"
                         for name, value in self.__dict__.items()
                         if name != "signature")
-        return f'<Interface: {self.signature}{attrs}>'
+        return f'<PureInterface: {self.signature}{attrs}>'
 
 
 # To reduce API surface area `FlippedInterface` is made final. This restriction could be lifted

--- a/tests/test_lib_wiring.py
+++ b/tests/test_lib_wiring.py
@@ -8,7 +8,7 @@ from amaranth.hdl.ast import ValueCastable
 from amaranth.lib import data, enum
 from amaranth.lib.wiring import Flow, In, Out, Member
 from amaranth.lib.wiring import SignatureError, SignatureMembers, FlippedSignatureMembers
-from amaranth.lib.wiring import Signature, FlippedSignature, Interface, FlippedInterface
+from amaranth.lib.wiring import Signature, FlippedSignature, PureInterface, FlippedInterface
 from amaranth.lib.wiring import Component
 from amaranth.lib.wiring import ConnectionError, connect, flipped
 
@@ -652,13 +652,13 @@ class FlippedSignatureTestCase(unittest.TestCase):
             sig.flip().members = SignatureMembers({})
 
 
-class InterfaceTestCase(unittest.TestCase):
+class PureInterfaceTestCase(unittest.TestCase):
     def test_construct(self):
         sig = Signature({
             "a": In(4),
             "b": Out(signed(2)),
         })
-        intf = Interface(sig, path=("test",))
+        intf = PureInterface(sig, path=("test",))
         self.assertIs(intf.signature, sig)
         self.assertIsInstance(intf.a, Signal)
         self.assertIsInstance(intf.b, Signal)
@@ -668,8 +668,8 @@ class InterfaceTestCase(unittest.TestCase):
             "a": In(4),
             "b": Out(signed(2)),
         })
-        intf = Interface(sig, path=("test",))
-        self.assertEqual(repr(intf), "<Interface: Signature({'a': In(4), 'b': Out(signed(2))}), a=(sig test__a), b=(sig test__b)>")
+        intf = PureInterface(sig, path=("test",))
+        self.assertEqual(repr(intf), "<PureInterface: Signature({'a': In(4), 'b': Out(signed(2))}), a=(sig test__a), b=(sig test__b)>")
 
 
 class FlippedInterfaceTestCase(unittest.TestCase):
@@ -681,8 +681,7 @@ class FlippedInterfaceTestCase(unittest.TestCase):
         tintf = flipped(intf)
         self.assertEqual(tintf.signature, intf.signature.flip())
         self.assertEqual(tintf, flipped(intf))
-        self.assertRegex(repr(tintf),
-            r"^flipped\(<Interface: .+>\)$")
+        self.assertRegex(repr(tintf), r"^flipped\(<PureInterface: .+>\)$")
         self.assertIs(flipped(tintf), intf)
 
     def test_getsetdelattr(self):
@@ -763,7 +762,7 @@ class FlippedInterfaceTestCase(unittest.TestCase):
             flipped(Signature({}))
 
     def test_create_subclass_flipped(self):
-        class CustomInterface(Interface):
+        class CustomInterface(PureInterface):
             def custom_method(self):
                 return 69
 


### PR DESCRIPTION
Closes #985.