### PR TITLE
Fix `__repr__` for PureInterface subclasses

### DIFF
--- a/amaranth/lib/wiring.py
+++ b/amaranth/lib/wiring.py
@@ -611,7 +611,7 @@ class PureInterface:
         attrs = ''.join(f", {name}={value!r}"
                         for name, value in self.__dict__.items()
                         if name != "signature")
-        return f'<PureInterface: {self.signature}{attrs}>'
+        return f'<{type(self).__name__}: {self.signature}{attrs}>'
 
 
 # To reduce API surface area `FlippedInterface` is made final. This restriction could be lifted

--- a/tests/test_lib_wiring.py
+++ b/tests/test_lib_wiring.py
@@ -671,6 +671,12 @@ class PureInterfaceTestCase(unittest.TestCase):
         intf = PureInterface(sig, path=("test",))
         self.assertEqual(repr(intf), "<PureInterface: Signature({'a': In(4), 'b': Out(signed(2))}), a=(sig test__a), b=(sig test__b)>")
 
+    def test_repr_inherit(self):
+        class CustomInterface(PureInterface):
+            pass
+        intf = CustomInterface(Signature({}), path=())
+        self.assertRegex(repr(intf), r"^<CustomInterface: .+?>$")
+
 
 class FlippedInterfaceTestCase(unittest.TestCase):
     def test_basic(self):


### PR DESCRIPTION
Fixes #988.