### PR TITLE
Make values of `wiring.In` and `wiring.Out` be strings "In" and "Out"

### DIFF
--- a/amaranth/lib/wiring.py
+++ b/amaranth/lib/wiring.py
@@ -15,8 +15,8 @@ __all__ = ["In", "Out", "Signature", "PureInterface", "connect", "flipped", "Com
 
 
 class Flow(enum.Enum):
-    Out = 0
-    In = 1
+    Out = "Out"
+    In = "In"
 
     def flip(self):
         if self == Out:

--- a/tests/test_lib_wiring.py
+++ b/tests/test_lib_wiring.py
@@ -26,6 +26,10 @@ class FlowTestCase(unittest.TestCase):
         self.assertEqual(str(Flow.In), "In")
         self.assertEqual(str(Flow.Out), "Out")
 
+    def test_flow_value(self):
+        self.assertEqual(Flow.In.value, "In")
+        self.assertEqual(Flow.Out.value, "Out")
+
 
 class MemberTestCase(unittest.TestCase):
     def test_port_member(self):


### PR DESCRIPTION
Their `str()` and `repr()` values are already that; and the 0 and 1 don't make sense. The RFC leaves it unspecified.