### PR TITLE
hdl.mem: Switch to first-class IR representation for memories.

### DIFF
--- a/amaranth/hdl/mem.py
+++ b/amaranth/hdl/mem.py
@@ -119,55 +119,7 @@ class Memory(Elaboratable):
         return self._array[index]
 
     def elaborate(self, platform):
-        init = "".join(format(Const(elem, unsigned(self.width)).value, f"0{self.width}b") for elem in reversed(self.init))
-        init = Const(int(init or "0", 2), self.depth * self.width)
-        rd_clk = []
-        rd_clk_enable = 0
-        rd_transparency_mask = 0
-        for index, port in enumerate(self._read_ports):
-            if port.domain != "comb":
-                rd_clk.append(ClockSignal(port.domain))
-                rd_clk_enable |= 1 << index
-                if port.transparent:
-                    for write_index, write_port in enumerate(self._write_ports):
-                        if port.domain == write_port.domain:
-                            rd_transparency_mask |= 1 << (index * len(self._write_ports) + write_index)
-            else:
-                rd_clk.append(Const(0, 1))
-        f = Instance("$mem_v2",
-            *(("a", attr, value) for attr, value in self.attrs.items()),
-            p_SIZE=self.depth,
-            p_OFFSET=0,
-            p_ABITS=Shape.cast(range(self.depth)).width,
-            p_WIDTH=self.width,
-            p_INIT=init,
-            p_RD_PORTS=len(self._read_ports),
-            p_RD_CLK_ENABLE=Const(rd_clk_enable, len(self._read_ports)) if self._read_ports else Const(0, 1),
-            p_RD_CLK_POLARITY=Const(-1, unsigned(len(self._read_ports))) if self._read_ports else Const(0, 1),
-            p_RD_TRANSPARENCY_MASK=Const(rd_transparency_mask, max(1, len(self._read_ports) * len(self._write_ports))),
-            p_RD_COLLISION_X_MASK=Const(0, max(1, len(self._read_ports) * len(self._write_ports))),
-            p_RD_WIDE_CONTINUATION=Const(0, len(self._read_ports)) if self._read_ports else Const(0, 1),
-            p_RD_CE_OVER_SRST=Const(0, len(self._read_ports)) if self._read_ports else Const(0, 1),
-            p_RD_ARST_VALUE=Const(0, len(self._read_ports) * self.width),
-            p_RD_SRST_VALUE=Const(0, len(self._read_ports) * self.width),
-            p_RD_INIT_VALUE=Const(0, len(self._read_ports) * self.width),
-            p_WR_PORTS=len(self._write_ports),
-            p_WR_CLK_ENABLE=Const(-1, unsigned(len(self._write_ports))) if self._write_ports else Const(0, 1),
-            p_WR_CLK_POLARITY=Const(-1, unsigned(len(self._write_ports))) if self._write_ports else Const(0, 1),
-            p_WR_PRIORITY_MASK=Const(0, len(self._write_ports) * len(self._write_ports)) if self._write_ports else Const(0, 1),
-            p_WR_WIDE_CONTINUATION=Const(0, len(self._write_ports)) if self._write_ports else Const(0, 1),
-            i_RD_CLK=Cat(rd_clk),
-            i_RD_EN=Cat(port.en for port in self._read_ports),
-            i_RD_ARST=Const(0, len(self._read_ports)),
-            i_RD_SRST=Const(0, len(self._read_ports)),
-            i_RD_ADDR=Cat(port.addr for port in self._read_ports),
-            o_RD_DATA=Cat(port.data for port in self._read_ports),
-            i_WR_CLK=Cat(ClockSignal(port.domain) for port in self._write_ports),
-            i_WR_EN=Cat(Cat(en_bit.replicate(port.granularity) for en_bit in port.en) for port in self._write_ports),
-            i_WR_ADDR=Cat(port.addr for port in self._write_ports),
-            i_WR_DATA=Cat(port.data for port in self._write_ports),
-            src_loc=self.src_loc,
-        )
+        f = MemoryInstance(self, self._read_ports, self._write_ports)
         for port in self._read_ports:
             port._MustUse__used = True
             if port.domain == "comb":
@@ -210,6 +162,7 @@ class Memory(Elaboratable):
             for signal in self._array:
                 f.add_driver(signal, port.domain)
         return f
+
 
 class ReadPort(Elaboratable):
     """A memory read port.
@@ -354,3 +307,12 @@ class DummyPort:
                            name=f"{name}_data", src_loc_at=1)
         self.en   = Signal(data_width // granularity,
                            name=f"{name}_en", src_loc_at=1)
+
+
+class MemoryInstance(Fragment):
+    def __init__(self, memory, read_ports, write_ports):
+        super().__init__()
+        self.memory = memory
+        self.read_ports = read_ports
+        self.write_ports = write_ports
+        self.attrs = memory.attrs

--- a/amaranth/hdl/xfrm.py
+++ b/amaranth/hdl/xfrm.py
@@ -1,6 +1,7 @@
 from abc import ABCMeta, abstractmethod
 from collections import OrderedDict
 from collections.abc import Iterable
+from copy import copy
 
 from .._utils import flatten, _ignore_deprecated
 from .. import tracer
@@ -8,6 +9,7 @@ from .ast import *
 from .ast import _StatementList
 from .cd import *
 from .ir import *
+from .mem import MemoryInstance
 
 
 __all__ = ["ValueVisitor", "ValueTransformer",
@@ -261,8 +263,30 @@ class FragmentTransformer:
         for domain, signal in fragment.iter_drivers():
             new_fragment.add_driver(signal, domain)
 
+    def map_memory_ports(self, fragment, new_fragment):
+        new_fragment.read_ports = [
+            copy(port)
+            for port in fragment.read_ports
+        ]
+        new_fragment.write_ports = [
+            copy(port)
+            for port in fragment.write_ports
+        ]
+        if hasattr(self, "on_value"):
+            for port in new_fragment.read_ports:
+                port.en = self.on_value(port.en)
+                port.addr = self.on_value(port.addr)
+                port.data = self.on_value(port.data)
+            for port in new_fragment.write_ports:
+                port.en = self.on_value(port.en)
+                port.addr = self.on_value(port.addr)
+                port.data = self.on_value(port.data)
+
     def on_fragment(self, fragment):
-        if isinstance(fragment, Instance):
+        if isinstance(fragment, MemoryInstance):
+            new_fragment = MemoryInstance(fragment.memory, [], [])
+            self.map_memory_ports(fragment, new_fragment)
+        elif isinstance(fragment, Instance):            
             new_fragment = Instance(fragment.type, src_loc=fragment.src_loc)
             new_fragment.parameters = OrderedDict(fragment.parameters)
             self.map_named_ports(fragment, new_fragment)
@@ -381,6 +405,19 @@ class DomainCollector(ValueVisitor, StatementVisitor):
             self.on_statement(stmt)
 
     def on_fragment(self, fragment):
+        if isinstance(fragment, MemoryInstance):
+            for port in fragment.read_ports:
+                self.on_value(port.addr)
+                self.on_value(port.data)
+                self.on_value(port.en)
+                if port.domain != "comb":
+                    self._add_used_domain(port.domain)
+            for port in fragment.write_ports:
+                self.on_value(port.addr)
+                self.on_value(port.data)
+                self.on_value(port.en)
+                self._add_used_domain(port.domain)
+
         if isinstance(fragment, Instance):
             for name, (value, dir) in fragment.named_ports.items():
                 self.on_value(value)
@@ -443,6 +480,15 @@ class DomainRenamer(FragmentTransformer, ValueTransformer, StatementTransformer)
                 domain = self.domain_map[domain]
             for signal in signals:
                 new_fragment.add_driver(self.on_value(signal), domain)
+
+    def map_memory_ports(self, fragment, new_fragment):
+        super().map_memory_ports(fragment, new_fragment)
+        for port in new_fragment.read_ports:
+            if port.domain in self.domain_map:
+                port.domain = self.domain_map[port.domain]
+        for port in new_fragment.write_ports:
+            if port.domain in self.domain_map:
+                port.domain = self.domain_map[port.domain]
 
 
 class DomainLowerer(FragmentTransformer, ValueTransformer, StatementTransformer):
@@ -630,14 +676,11 @@ class EnableInserter(_ControlInserter):
 
     def on_fragment(self, fragment):
         new_fragment = super().on_fragment(fragment)
-        if isinstance(new_fragment, Instance) and new_fragment.type == "$mem_v2":
-            for kind in ["RD", "WR"]:
-                clk_parts = new_fragment.named_ports[kind + "_CLK"][0].parts
-                en_parts = new_fragment.named_ports[kind + "_EN"][0].parts
-                new_en = []
-                for clk, en in zip(clk_parts, en_parts):
-                    if isinstance(clk, ClockSignal) and clk.domain in self.controls:
-                        en = Mux(self.controls[clk.domain], en, Const(0, len(en)))
-                    new_en.append(en)
-                new_fragment.named_ports[kind + "_EN"] = Cat(new_en), "i"
+        if isinstance(new_fragment, MemoryInstance):
+            for port in new_fragment.read_ports:
+                if port.domain in self.controls:
+                    port.en = port.en & self.controls[port.domain]
+            for port in new_fragment.write_ports:
+                if port.domain in self.controls:
+                    port.en = Mux(self.controls[port.domain], port.en, Const(0, len(port.en)))
         return new_fragment


### PR DESCRIPTION
Extracted from the new IR branch as a standalone PR.

Fixes #611.