### PR TITLE
back.verilog: forbid Yosys version range with dangling else bug.

### DIFF
--- a/amaranth/back/verilog.py
+++ b/amaranth/back/verilog.py
@@ -9,7 +9,9 @@ __all__ = ["YosysError", "convert", "convert_fragment"]
 
 def _convert_rtlil_text(rtlil_text, *, strip_internal_attrs=False, write_verilog_opts=()):
     # this version requirement needs to be synchronized with the one in pyproject.toml!
-    yosys = find_yosys(lambda ver: ver >= (0, 35))
+    # Yosys 0.37 has a critical miscompilation in Verilog backend:
+    # https://github.com/amaranth-lang/amaranth/issues/1049
+    yosys = find_yosys(lambda ver: ver >= (0, 35) and not (0, 36, 79) <= ver <= (0, 37, 29))
 
     script = []
     script.append(f"read_ilang <<rtlil\n{rtlil_text}\nrtlil")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 
 [project.optional-dependencies]
 # this version requirement needs to be synchronized with the one in amaranth.back.verilog!
-builtin-yosys = ["amaranth-yosys>=0.35"]
+builtin-yosys = ["amaranth-yosys>=0.35,!=0.37.0.*"]
 remote-build  = ["paramiko~=2.7"]
 
 [project.scripts]
@@ -49,7 +49,7 @@ includes = ["amaranth/"]
 
 [tool.pdm.dev-dependencies]
 test = [
-  "yowasp-yosys",
+  "yowasp-yosys!=0.37.0.*",
   "coverage",
 ]
 docs = [


### PR DESCRIPTION
Fixes #1049.

This can be merged once https://github.com/YosysHQ/yosys/pull/4150 is in and the version range is final.