### PR TITLE
Add missing compatibility shims in `amaranth.hdl`

### DIFF
--- a/amaranth/hdl/ast.py
+++ b/amaranth/hdl/ast.py
@@ -1,0 +1,32 @@
+# TODO(amaranth-0.6): remove module
+
+from .. import hdl as __hdl
+from . import _ast as __origin
+
+
+__all__ = [
+    "Shape", "signed", "unsigned", "ShapeCastable", "ShapeLike",
+    "Value", "Const", "C", "AnyConst", "AnySeq", "Operator", "Mux", "Part", "Slice", "Cat", "Repl",
+    "Array", "ArrayProxy",
+    "Signal", "ClockSignal", "ResetSignal",
+    "ValueCastable", "ValueLike",
+    "Initial",
+    "Statement", "Switch",
+    "Property", "Assign", "Assert", "Assume", "Cover",
+    "ValueKey", "ValueDict", "ValueSet", "SignalKey", "SignalDict", "SignalSet",
+]
+
+
+def __getattr__(name):
+    import warnings
+    if name in __hdl.__dict__:
+        if not (name.startswith("__") and name.endswith("__")):
+            warnings.warn(f"instead of `{__name__}.{name}`, use `{__hdl.__name__}.{name}`",
+                        DeprecationWarning, stacklevel=2)
+        return getattr(__origin, name)
+    elif name in __origin.__dict__:
+        warnings.warn(f"name `{__name__}.{name}` is a private implementation detail and "
+                      f"should not be imported",
+                      DeprecationWarning, stacklevel=2)
+        return getattr(__origin, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/amaranth/hdl/cd.py
+++ b/amaranth/hdl/cd.py
@@ -1,0 +1,22 @@
+# TODO(amaranth-0.6): remove module
+
+from .. import hdl as __hdl
+from . import _cd as __origin
+
+
+__all__ = ["ClockDomain", "DomainError"]
+
+
+def __getattr__(name):
+    import warnings
+    if name in __hdl.__dict__:
+        if not (name.startswith("__") and name.endswith("__")):
+            warnings.warn(f"instead of `{__name__}.{name}`, use `{__hdl.__name__}.{name}`",
+                        DeprecationWarning, stacklevel=2)
+        return getattr(__origin, name)
+    elif name in __origin.__dict__:
+        warnings.warn(f"name `{__name__}.{name}` is a private implementation detail and "
+                      f"should not be imported",
+                      DeprecationWarning, stacklevel=2)
+        return getattr(__origin, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/amaranth/hdl/dsl.py
+++ b/amaranth/hdl/dsl.py
@@ -1,0 +1,22 @@
+# TODO(amaranth-0.6): remove module
+
+from .. import hdl as __hdl
+from . import _dsl as __origin
+
+
+__all__ = ["SyntaxError", "SyntaxWarning", "Module"]
+
+
+def __getattr__(name):
+    import warnings
+    if name in __hdl.__dict__:
+        if not (name.startswith("__") and name.endswith("__")):
+            warnings.warn(f"instead of `{__name__}.{name}`, use `{__hdl.__name__}.{name}`",
+                        DeprecationWarning, stacklevel=2)
+        return getattr(__origin, name)
+    elif name in __origin.__dict__:
+        warnings.warn(f"name `{__name__}.{name}` is a private implementation detail and "
+                      f"should not be imported",
+                      DeprecationWarning, stacklevel=2)
+        return getattr(__origin, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/amaranth/hdl/ir.py
+++ b/amaranth/hdl/ir.py
@@ -1,0 +1,22 @@
+# TODO(amaranth-0.6): remove module
+
+from .. import hdl as __hdl
+from . import _ir as __origin
+
+
+__all__ = ["UnusedElaboratable", "Elaboratable", "DriverConflict", "Fragment", "Instance"]
+
+
+def __getattr__(name):
+    import warnings
+    if name in __hdl.__dict__:
+        if not (name.startswith("__") and name.endswith("__")):
+            warnings.warn(f"instead of `{__name__}.{name}`, use `{__hdl.__name__}.{name}`",
+                        DeprecationWarning, stacklevel=2)
+        return getattr(__origin, name)
+    elif name in __origin.__dict__:
+        warnings.warn(f"name `{__name__}.{name}` is a private implementation detail and "
+                      f"should not be imported",
+                      DeprecationWarning, stacklevel=2)
+        return getattr(__origin, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/amaranth/hdl/mem.py
+++ b/amaranth/hdl/mem.py
@@ -1,0 +1,22 @@
+# TODO(amaranth-0.6): remove module
+
+from .. import hdl as __hdl
+from . import _mem as __origin
+
+
+__all__ = ["Memory", "ReadPort", "WritePort", "DummyPort"]
+
+
+def __getattr__(name):
+    import warnings
+    if name in __hdl.__dict__:
+        if not (name.startswith("__") and name.endswith("__")):
+            warnings.warn(f"instead of `{__name__}.{name}`, use `{__hdl.__name__}.{name}`",
+                        DeprecationWarning, stacklevel=2)
+        return getattr(__origin, name)
+    elif name in __origin.__dict__:
+        warnings.warn(f"name `{__name__}.{name}` is a private implementation detail and "
+                      f"should not be imported",
+                      DeprecationWarning, stacklevel=2)
+        return getattr(__origin, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/amaranth/hdl/xfrm.py
+++ b/amaranth/hdl/xfrm.py
@@ -1,0 +1,28 @@
+# TODO(amaranth-0.6): remove module
+
+from .. import hdl as __hdl
+from . import _xfrm as __origin
+
+
+__all__ = ["ValueVisitor", "ValueTransformer",
+           "StatementVisitor", "StatementTransformer",
+           "FragmentTransformer",
+           "TransformedElaboratable",
+           "DomainCollector", "DomainRenamer", "DomainLowerer",
+           "SwitchCleaner", "LHSGroupAnalyzer", "LHSGroupFilter",
+           "ResetInserter", "EnableInserter"]
+
+
+def __getattr__(name):
+    import warnings
+    if name in __hdl.__dict__:
+        if not (name.startswith("__") and name.endswith("__")):
+            warnings.warn(f"instead of `{__name__}.{name}`, use `{__hdl.__name__}.{name}`",
+                        DeprecationWarning, stacklevel=2)
+        return getattr(__origin, name)
+    elif name in __origin.__dict__:
+        warnings.warn(f"name `{__name__}.{name}` is a private implementation detail and "
+                      f"should not be imported",
+                      DeprecationWarning, stacklevel=2)
+        return getattr(__origin, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
These were originally planned to be committed as a part of 5dd1223c, but were lost during rebasing.