### PR TITLE
lib.fifo: add `Memory` as submodules instead of its ports. [NFC]

### DIFF
--- a/amaranth/lib/fifo.py
+++ b/amaranth/lib/fifo.py
@@ -130,9 +130,9 @@ class SyncFIFO(Elaboratable, FIFOInterface):
         do_read  = self.r_rdy & self.r_en
         do_write = self.w_rdy & self.w_en
 
-        storage = Memory(width=self.width, depth=self.depth)
-        w_port  = m.submodules.w_port = storage.write_port()
-        r_port  = m.submodules.r_port = storage.read_port(domain="comb")
+        storage = m.submodules.storage = Memory(width=self.width, depth=self.depth)
+        w_port  = storage.write_port()
+        r_port  = storage.read_port(domain="comb")
         produce = Signal(range(self.depth))
         consume = Signal(range(self.depth))
 
@@ -257,7 +257,7 @@ class SyncFIFOBuffered(Elaboratable, FIFOInterface):
 
         do_inner_read  = inner_r_rdy & (~self.r_rdy | self.r_en)
 
-        m.submodules.storage = storage = Memory(width=self.width, depth=inner_depth)
+        storage = m.submodules.storage = Memory(width=self.width, depth=inner_depth)
         w_port  = storage.write_port()
         r_port  = storage.read_port(domain="sync", transparent=False)
         produce = Signal(range(inner_depth))
@@ -438,10 +438,9 @@ class AsyncFIFO(Elaboratable, FIFOInterface):
         m.d[self._w_domain] += self.w_level.eq(produce_w_bin - consume_w_bin)
         m.d.comb += self.r_level.eq(produce_r_bin - consume_r_bin)
 
-        storage = Memory(width=self.width, depth=self.depth)
-        w_port  = m.submodules.w_port = storage.write_port(domain=self._w_domain)
-        r_port  = m.submodules.r_port = storage.read_port (domain=self._r_domain,
-                                                           transparent=False)
+        storage = m.submodules.storage = Memory(width=self.width, depth=self.depth)
+        w_port  = storage.write_port(domain=self._w_domain)
+        r_port  = storage.read_port (domain=self._r_domain, transparent=False)
         m.d.comb += [
             w_port.addr.eq(produce_w_bin[:-1]),
             w_port.data.eq(self.w_data),


### PR DESCRIPTION
This makes the generated netlist very slightly nicer.