### PR TITLE
Remove subclassing of `AnyValue` and `Property`

### DIFF
--- a/amaranth/hdl/_dsl.py
+++ b/amaranth/hdl/_dsl.py
@@ -506,7 +506,7 @@ class Module(_ModuleBuilderRoot, Elaboratable):
             self._pop_ctrl()
 
         for stmt in Statement.cast(assigns):
-            if not isinstance(stmt, (Assign, Assert, Assume, Cover)):
+            if not isinstance(stmt, (Assign, Property)):
                 raise SyntaxError(
                     "Only assignments and property checks may be appended to d.{}"
                     .format(domain_name(domain)))

--- a/amaranth/hdl/_xfrm.py
+++ b/amaranth/hdl/_xfrm.py
@@ -6,7 +6,7 @@ from copy import copy
 from .._utils import flatten, _ignore_deprecated
 from .. import tracer
 from ._ast import *
-from ._ast import _StatementList
+from ._ast import _StatementList, AnyValue, Property
 from ._cd import *
 from ._ir import *
 from ._mem import MemoryInstance
@@ -27,14 +27,6 @@ class ValueVisitor(metaclass=ABCMeta):
         pass # :nocov:
 
     @abstractmethod
-    def on_AnyConst(self, value):
-        pass # :nocov:
-
-    @abstractmethod
-    def on_AnySeq(self, value):
-        pass # :nocov:
-
-    @abstractmethod
     def on_Signal(self, value):
         pass # :nocov:
 
@@ -44,6 +36,10 @@ class ValueVisitor(metaclass=ABCMeta):
 
     @abstractmethod
     def on_ResetSignal(self, value):
+        pass # :nocov:
+
+    @abstractmethod
+    def on_AnyValue(self, value):
         pass # :nocov:
 
     @abstractmethod
@@ -79,16 +75,14 @@ class ValueVisitor(metaclass=ABCMeta):
     def on_value(self, value):
         if type(value) is Const:
             new_value = self.on_Const(value)
-        elif type(value) is AnyConst:
-            new_value = self.on_AnyConst(value)
-        elif type(value) is AnySeq:
-            new_value = self.on_AnySeq(value)
         elif type(value) is Signal:
             new_value = self.on_Signal(value)
         elif type(value) is ClockSignal:
             new_value = self.on_ClockSignal(value)
         elif type(value) is ResetSignal:
             new_value = self.on_ResetSignal(value)
+        elif type(value) is AnyValue:
+            new_value = self.on_AnyValue(value)
         elif type(value) is Operator:
             new_value = self.on_Operator(value)
         elif type(value) is Slice:
@@ -115,12 +109,6 @@ class ValueTransformer(ValueVisitor):
     def on_Const(self, value):
         return value
 
-    def on_AnyConst(self, value):
-        return value
-
-    def on_AnySeq(self, value):
-        return value
-
     def on_Signal(self, value):
         return value
 
@@ -128,6 +116,9 @@ class ValueTransformer(ValueVisitor):
         return value
 
     def on_ResetSignal(self, value):
+        return value
+
+    def on_AnyValue(self, value):
         return value
 
     def on_Operator(self, value):
@@ -157,15 +148,7 @@ class StatementVisitor(metaclass=ABCMeta):
         pass # :nocov:
 
     @abstractmethod
-    def on_Assert(self, stmt):
-        pass # :nocov:
-
-    @abstractmethod
-    def on_Assume(self, stmt):
-        pass # :nocov:
-
-    @abstractmethod
-    def on_Cover(self, stmt):
+    def on_Property(self, stmt):
         pass # :nocov:
 
     @abstractmethod
@@ -185,12 +168,8 @@ class StatementVisitor(metaclass=ABCMeta):
     def on_statement(self, stmt):
         if type(stmt) is Assign:
             new_stmt = self.on_Assign(stmt)
-        elif type(stmt) is Assert:
-            new_stmt = self.on_Assert(stmt)
-        elif type(stmt) is Assume:
-            new_stmt = self.on_Assume(stmt)
-        elif type(stmt) is Cover:
-            new_stmt = self.on_Cover(stmt)
+        elif type(stmt) is Property:
+            new_stmt = self.on_Property(stmt)
         elif type(stmt) is Switch:
             new_stmt = self.on_Switch(stmt)
         elif isinstance(stmt, Iterable):
@@ -216,14 +195,8 @@ class StatementTransformer(StatementVisitor):
     def on_Assign(self, stmt):
         return Assign(self.on_value(stmt.lhs), self.on_value(stmt.rhs))
 
-    def on_Assert(self, stmt):
-        return Assert(self.on_value(stmt.test), _check=stmt._check, _en=stmt._en, name=stmt.name)
-
-    def on_Assume(self, stmt):
-        return Assume(self.on_value(stmt.test), _check=stmt._check, _en=stmt._en, name=stmt.name)
-
-    def on_Cover(self, stmt):
-        return Cover(self.on_value(stmt.test), _check=stmt._check, _en=stmt._en, name=stmt.name)
+    def on_Property(self, stmt):
+        return Property(stmt.kind, self.on_value(stmt.test), _check=stmt._check, _en=stmt._en, name=stmt.name)
 
     def on_Switch(self, stmt):
         cases = OrderedDict((k, self.on_statement(s)) for k, s in stmt.cases.items())
@@ -351,9 +324,8 @@ class DomainCollector(ValueVisitor, StatementVisitor):
         pass
 
     on_Const = on_ignore
-    on_AnyConst = on_ignore
-    on_AnySeq = on_ignore
     on_Signal = on_ignore
+    on_AnyValue = on_ignore
 
     def on_ClockSignal(self, value):
         self._add_used_domain(value.domain)
@@ -388,12 +360,8 @@ class DomainCollector(ValueVisitor, StatementVisitor):
         self.on_value(stmt.lhs)
         self.on_value(stmt.rhs)
 
-    def on_property(self, stmt):
+    def on_Property(self, stmt):
         self.on_value(stmt.test)
-
-    on_Assert = on_property
-    on_Assume = on_property
-    on_Cover  = on_property
 
     def on_Switch(self, stmt):
         self.on_value(stmt.test)
@@ -544,10 +512,8 @@ class SwitchCleaner(StatementVisitor):
     def on_ignore(self, stmt):
         return stmt
 
-    on_Assign = on_ignore
-    on_Assert = on_ignore
-    on_Assume = on_ignore
-    on_Cover  = on_ignore
+    on_Assign   = on_ignore
+    on_Property = on_ignore
 
     def on_Switch(self, stmt):
         cases = OrderedDict((k, self.on_statement(s)) for k, s in stmt.cases.items())
@@ -595,14 +561,10 @@ class LHSGroupAnalyzer(StatementVisitor):
         if lhs_signals:
             self.unify(*stmt._lhs_signals())
 
-    def on_property(self, stmt):
+    def on_Property(self, stmt):
         lhs_signals = stmt._lhs_signals()
         if lhs_signals:
             self.unify(*stmt._lhs_signals())
-
-    on_Assert = on_property
-    on_Assume = on_property
-    on_Cover  = on_property
 
     def on_Switch(self, stmt):
         for case_stmts in stmt.cases.values():
@@ -630,14 +592,10 @@ class LHSGroupFilter(SwitchCleaner):
             if any_lhs_signal in self.signals:
                 return stmt
 
-    def on_property(self, stmt):
+    def on_Property(self, stmt):
         any_lhs_signal = next(iter(stmt._lhs_signals()))
         if any_lhs_signal in self.signals:
             return stmt
-
-    on_Assert = on_property
-    on_Assume = on_property
-    on_Cover  = on_property
 
 
 class _ControlInserter(FragmentTransformer):

--- a/amaranth/sim/_pyrtl.py
+++ b/amaranth/sim/_pyrtl.py
@@ -97,10 +97,7 @@ class _ValueCompiler(ValueVisitor, _Compiler):
     def on_ResetSignal(self, value):
         raise NotImplementedError # :nocov:
 
-    def on_AnyConst(self, value):
-        raise NotImplementedError # :nocov:
-
-    def on_AnySeq(self, value):
+    def on_AnyValue(self, value):
         raise NotImplementedError # :nocov:
 
     def on_Initial(self, value):
@@ -389,13 +386,7 @@ class _StatementCompiler(StatementVisitor, _Compiler):
             with self.emitter.indent():
                 self(stmts)
 
-    def on_Assert(self, stmt):
-        raise NotImplementedError # :nocov:
-
-    def on_Assume(self, stmt):
-        raise NotImplementedError # :nocov:
-
-    def on_Cover(self, stmt):
+    def on_Property(self, stmt):
         raise NotImplementedError # :nocov:
 
     @classmethod


### PR DESCRIPTION
This subclassing is unnecessary and makes downstream code more complex. In the new IR, they are unified into cells with the same name anyway. Even before that, this change simplifies things.