### PR TITLE
Remove features deprecated in past releases

### DIFF
--- a/amaranth/build/plat.py
+++ b/amaranth/build/plat.py
@@ -73,14 +73,6 @@ class Platform(ResourceManager, metaclass=ABCMeta):
     def _toolchain_env_var(self):
         return f"AMARANTH_ENV_{tool_env_var(self.toolchain)}"
 
-    # TODO(amaranth-0.5): remove
-    @property
-    def _all_toolchain_env_vars(self):
-        return (
-            f"AMARANTH_ENV_{self.toolchain.replace('-', '_').replace('+', 'X')}",
-            self._toolchain_env_var,
-        )
-
     def build(self, elaboratable, name="top",
               build_dir="build", do_build=True,
               program_opts=None, do_program=False,

--- a/amaranth/build/run.py
+++ b/amaranth/build/run.py
@@ -116,7 +116,7 @@ class BuildPlan:
             else:
                 subprocess.check_call(["sh", f"{self.script}.sh"],
                                       cwd=build_dir, env=os.environ if env is None else env)
-        # TODO(amaranth-0.5): remove
+        # TODO(amaranth-0.6): remove
         if run_script is not None:
             warnings.warn("The `run_script` argument is deprecated. If you only want to "
                             "extract the files from the BuildPlan, use the .extract() method",

--- a/amaranth/vendor/_lattice_machxo_2_3l.py
+++ b/amaranth/vendor/_lattice_machxo_2_3l.py
@@ -135,14 +135,6 @@ class LatticeMachXO2Or3LPlatform(TemplatedPlatform):
             -oft -svfsingle -revd -op "FLASH Erase,Program,Verify"
             -if {{name}}_impl/{{name}}_impl.jed -of {{name}}_flash.svf
         """,
-        # TODO(amaranth-0.4): remove
-        r"""
-        {% if syntax == "bat" -%}
-        copy {{name}}_flash.svf {{name}}.svf
-        {% else -%}
-        cp {{name}}_flash.svf {{name}}.svf
-        {% endif %}
-        """,
         r"""
         {{invoke_tool("ddtcmd")}}
             -oft -svfsingle -revd -op "SRAM Fast Program"


### PR DESCRIPTION
Some of these were forgotten previously.

Also, fix a comment in `BuildPlan.execute_local` to use the correct version.