### PR TITLE
hdl.ir: associate statements with domains.

### DIFF
--- a/amaranth/hdl/_ast.py
+++ b/amaranth/hdl/_ast.py
@@ -1706,6 +1706,12 @@ class _StatementList(list):
     def __repr__(self):
         return "({})".format(" ".join(map(repr, self)))
 
+    def _lhs_signals(self):
+        return union((s._lhs_signals() for s in self), start=SignalSet())
+
+    def _rhs_signals(self):
+        return union((s._rhs_signals() for s in self), start=SignalSet())
+
 
 class Statement:
     def __init__(self, *, src_loc_at=0):
@@ -1837,13 +1843,10 @@ class Switch(Statement):
                 self.case_src_locs[new_keys] = case_src_locs[orig_keys]
 
     def _lhs_signals(self):
-        signals = union((s._lhs_signals() for ss in self.cases.values() for s in ss),
-                        start=SignalSet())
-        return signals
+        return union((s._lhs_signals() for s in self.cases.values()), start=SignalSet())
 
     def _rhs_signals(self):
-        signals = union((s._rhs_signals() for ss in self.cases.values() for s in ss),
-                        start=SignalSet())
+        signals = union((s._rhs_signals() for s in self.cases.values()), start=SignalSet())
         return self.test._rhs_signals() | signals
 
     def __repr__(self):

--- a/amaranth/hdl/_mem.py
+++ b/amaranth/hdl/_mem.py
@@ -124,7 +124,7 @@ class Memory(Elaboratable):
             port._MustUse__used = True
             if port.domain == "comb":
                 # Asynchronous port
-                f.add_statements(port.data.eq(self._array[port.addr]))
+                f.add_statements(None, port.data.eq(self._array[port.addr]))
                 f.add_driver(port.data)
             else:
                 # Synchronous port
@@ -143,6 +143,7 @@ class Memory(Elaboratable):
                             cond = write_port.en & (port.addr == write_port.addr)
                             data = Mux(cond, write_port.data, data)
                 f.add_statements(
+                    port.domain,
                     Switch(port.en, {
                         1: port.data.eq(data)
                     })
@@ -155,10 +156,10 @@ class Memory(Elaboratable):
                     offset = index * port.granularity
                     bits   = slice(offset, offset + port.granularity)
                     write_data = self._array[port.addr][bits].eq(port.data[bits])
-                    f.add_statements(Switch(en_bit, { 1: write_data }))
+                    f.add_statements(port.domain, Switch(en_bit, { 1: write_data }))
             else:
                 write_data = self._array[port.addr].eq(port.data)
-                f.add_statements(Switch(port.en, { 1: write_data }))
+                f.add_statements(port.domain, Switch(port.en, { 1: write_data }))
             for signal in self._array:
                 f.add_driver(signal, port.domain)
         return f

--- a/amaranth/sim/_pyrtl.py
+++ b/amaranth/sim/_pyrtl.py
@@ -5,7 +5,7 @@ import sys
 
 from ..hdl import *
 from ..hdl._ast import SignalSet
-from ..hdl._xfrm import ValueVisitor, StatementVisitor, LHSGroupFilter
+from ..hdl._xfrm import ValueVisitor, StatementVisitor
 from ._base import BaseProcess
 
 
@@ -409,9 +409,9 @@ class _FragmentCompiler:
     def __call__(self, fragment):
         processes = set()
 
-        for domain_name, domain_signals in fragment.drivers.items():
-            domain_stmts = LHSGroupFilter(domain_signals)(fragment.statements)
+        for domain_name, domain_stmts in fragment.statements.items():
             domain_process = PyRTLProcess(is_comb=domain_name is None)
+            domain_signals = domain_stmts._lhs_signals()
 
             emitter = _PythonEmitter()
             emitter.append(f"def run():")

--- a/tests/test_hdl_ir.py
+++ b/tests/test_hdl_ir.py
@@ -100,6 +100,7 @@ class FragmentPortsTestCase(FHDLTestCase):
     def test_self_contained(self):
         f = Fragment()
         f.add_statements(
+            None,
             self.c1.eq(self.s1),
             self.s1.eq(self.c1)
         )
@@ -110,6 +111,7 @@ class FragmentPortsTestCase(FHDLTestCase):
     def test_infer_input(self):
         f = Fragment()
         f.add_statements(
+            None,
             self.c1.eq(self.s1)
         )
 
@@ -121,6 +123,7 @@ class FragmentPortsTestCase(FHDLTestCase):
     def test_request_output(self):
         f = Fragment()
         f.add_statements(
+            None,
             self.c1.eq(self.s1)
         )
 
@@ -133,10 +136,12 @@ class FragmentPortsTestCase(FHDLTestCase):
     def test_input_in_subfragment(self):
         f1 = Fragment()
         f1.add_statements(
+            None,
             self.c1.eq(self.s1)
         )
         f2 = Fragment()
         f2.add_statements(
+            None,
             self.s1.eq(0)
         )
         f1.add_subfragment(f2)
@@ -150,6 +155,7 @@ class FragmentPortsTestCase(FHDLTestCase):
         f1 = Fragment()
         f2 = Fragment()
         f2.add_statements(
+            None,
             self.c1.eq(self.s1)
         )
         f1.add_subfragment(f2)
@@ -164,10 +170,12 @@ class FragmentPortsTestCase(FHDLTestCase):
     def test_output_from_subfragment(self):
         f1 = Fragment()
         f1.add_statements(
+            None,
             self.c1.eq(0)
         )
         f2 = Fragment()
         f2.add_statements(
+            None,
             self.c2.eq(1)
         )
         f1.add_subfragment(f2)
@@ -183,15 +191,18 @@ class FragmentPortsTestCase(FHDLTestCase):
     def test_output_from_subfragment_2(self):
         f1 = Fragment()
         f1.add_statements(
+            None,
             self.c1.eq(self.s1)
         )
         f2 = Fragment()
         f2.add_statements(
+            None,
             self.c2.eq(self.s1)
         )
         f1.add_subfragment(f2)
         f3 = Fragment()
         f3.add_statements(
+            None,
             self.s1.eq(0)
         )
         f2.add_subfragment(f3)
@@ -205,11 +216,13 @@ class FragmentPortsTestCase(FHDLTestCase):
         f1 = Fragment()
         f2 = Fragment()
         f2.add_statements(
+            None,
             self.c1.eq(self.c2)
         )
         f1.add_subfragment(f2)
         f3 = Fragment()
         f3.add_statements(
+            None,
             self.c2.eq(0)
         )
         f3.add_driver(self.c2)
@@ -222,12 +235,14 @@ class FragmentPortsTestCase(FHDLTestCase):
         f1 = Fragment()
         f2 = Fragment()
         f2.add_statements(
+            None,
             self.c2.eq(0)
         )
         f2.add_driver(self.c2)
         f1.add_subfragment(f2)
         f3 = Fragment()
         f3.add_statements(
+            None,
             self.c1.eq(self.c2)
         )
         f1.add_subfragment(f3)
@@ -239,6 +254,7 @@ class FragmentPortsTestCase(FHDLTestCase):
         sync = ClockDomain()
         f = Fragment()
         f.add_statements(
+            "sync",
             self.c1.eq(self.s1)
         )
         f.add_domains(sync)
@@ -255,6 +271,7 @@ class FragmentPortsTestCase(FHDLTestCase):
         sync = ClockDomain(reset_less=True)
         f = Fragment()
         f.add_statements(
+            "sync",
             self.c1.eq(self.s1)
         )
         f.add_domains(sync)
@@ -490,7 +507,7 @@ class FragmentDomainsTestCase(FHDLTestCase):
     def test_propagate_missing(self):
         s1 = Signal()
         f1 = Fragment()
-        f1.add_driver(s1, "sync")
+        f1.add_statements("sync", s1.eq(1))
 
         with self.assertRaisesRegex(DomainError,
                 r"^Domain 'sync' is used but not defined$"):
@@ -499,7 +516,7 @@ class FragmentDomainsTestCase(FHDLTestCase):
     def test_propagate_create_missing(self):
         s1 = Signal()
         f1 = Fragment()
-        f1.add_driver(s1, "sync")
+        f1.add_statements("sync", s1.eq(1))
         f2 = Fragment()
         f1.add_subfragment(f2)
 
@@ -512,7 +529,7 @@ class FragmentDomainsTestCase(FHDLTestCase):
     def test_propagate_create_missing_fragment(self):
         s1 = Signal()
         f1 = Fragment()
-        f1.add_driver(s1, "sync")
+        f1.add_statements("sync", s1.eq(1))
 
         cd = ClockDomain("sync")
         f2 = Fragment()
@@ -529,7 +546,7 @@ class FragmentDomainsTestCase(FHDLTestCase):
     def test_propagate_create_missing_fragment_many_domains(self):
         s1 = Signal()
         f1 = Fragment()
-        f1.add_driver(s1, "sync")
+        f1.add_statements("sync", s1.eq(1))
 
         cd_por  = ClockDomain("por")
         cd_sync = ClockDomain("sync")
@@ -548,7 +565,7 @@ class FragmentDomainsTestCase(FHDLTestCase):
     def test_propagate_create_missing_fragment_wrong(self):
         s1 = Signal()
         f1 = Fragment()
-        f1.add_driver(s1, "sync")
+        f1.add_statements("sync", s1.eq(1))
 
         f2 = Fragment()
         f2.add_domains(ClockDomain("foo"))
@@ -566,7 +583,7 @@ class FragmentHierarchyConflictTestCase(FHDLTestCase):
         self.c2 = Signal()
 
         self.f1 = Fragment()
-        self.f1.add_statements(self.c1.eq(0))
+        self.f1.add_statements("sync", self.c1.eq(0))
         self.f1.add_driver(self.s1)
         self.f1.add_driver(self.c1, "sync")
 
@@ -574,7 +591,7 @@ class FragmentHierarchyConflictTestCase(FHDLTestCase):
         self.f1.add_subfragment(self.f1a, "f1a")
 
         self.f2 = Fragment()
-        self.f2.add_statements(self.c2.eq(1))
+        self.f2.add_statements("sync", self.c2.eq(1))
         self.f2.add_driver(self.s1)
         self.f2.add_driver(self.c2, "sync")
         self.f1.add_subfragment(self.f2)
@@ -594,7 +611,7 @@ class FragmentHierarchyConflictTestCase(FHDLTestCase):
             (self.f1b, "f1b"),
             (self.f2a, "f2a"),
         ])
-        self.assertRepr(self.f1.statements, """
+        self.assertRepr(self.f1.statements["sync"], """
         (
             (eq (sig c1) (const 1'd0))
             (eq (sig c2) (const 1'd1))
@@ -629,12 +646,12 @@ class FragmentHierarchyConflictTestCase(FHDLTestCase):
 
         self.f2 = Fragment()
         self.f2.add_driver(self.s1)
-        self.f2.add_statements(self.c1.eq(0))
+        self.f2.add_statements(None, self.c1.eq(0))
         self.f1.add_subfragment(self.f2)
 
         self.f3 = Fragment()
         self.f3.add_driver(self.s1)
-        self.f3.add_statements(self.c2.eq(1))
+        self.f3.add_statements(None, self.c2.eq(1))
         self.f1.add_subfragment(self.f3)
 
     def test_conflict_sub_sub(self):
@@ -642,7 +659,7 @@ class FragmentHierarchyConflictTestCase(FHDLTestCase):
 
         self.f1._resolve_hierarchy_conflicts(mode="silent")
         self.assertEqual(self.f1.subfragments, [])
-        self.assertRepr(self.f1.statements, """
+        self.assertRepr(self.f1.statements[None], """
         (
             (eq (sig c1) (const 1'd0))
             (eq (sig c2) (const 1'd1))
@@ -658,12 +675,12 @@ class FragmentHierarchyConflictTestCase(FHDLTestCase):
         self.f1.add_driver(self.s1)
 
         self.f2 = Fragment()
-        self.f2.add_statements(self.c1.eq(0))
+        self.f2.add_statements(None, self.c1.eq(0))
         self.f1.add_subfragment(self.f2)
 
         self.f3 = Fragment()
         self.f3.add_driver(self.s1)
-        self.f3.add_statements(self.c2.eq(1))
+        self.f3.add_statements(None, self.c2.eq(1))
         self.f2.add_subfragment(self.f3)
 
     def test_conflict_self_subsub(self):
@@ -671,7 +688,7 @@ class FragmentHierarchyConflictTestCase(FHDLTestCase):
 
         self.f1._resolve_hierarchy_conflicts(mode="silent")
         self.assertEqual(self.f1.subfragments, [])
-        self.assertRepr(self.f1.statements, """
+        self.assertRepr(self.f1.statements[None], """
         (
             (eq (sig c1) (const 1'd0))
             (eq (sig c2) (const 1'd1))
@@ -848,11 +865,11 @@ class InstanceTestCase(FHDLTestCase):
         f.add_domains(cd_sync_norst := ClockDomain(reset_less=True))
         f.add_ports((i, rst), dir="i")
         f.add_ports((o1, o2, o3), dir="o")
-        f.add_statements([o1.eq(0)])
+        f.add_statements(None, [o1.eq(0)])
         f.add_driver(o1, domain=None)
-        f.add_statements([o2.eq(i1)])
+        f.add_statements("sync", [o2.eq(i1)])
         f.add_driver(o2, domain="sync")
-        f.add_statements([o3.eq(i1)])
+        f.add_statements("sync_norst", [o3.eq(i1)])
         f.add_driver(o3, domain="sync_norst")
 
         names = f._assign_names_to_signals()

--- a/tests/test_hdl_xfrm.py
+++ b/tests/test_hdl_xfrm.py
@@ -26,26 +26,35 @@ class DomainRenamerTestCase(FHDLTestCase):
     def test_rename_signals(self):
         f = Fragment()
         f.add_statements(
+            None,
             self.s1.eq(ClockSignal()),
             ResetSignal().eq(self.s2),
-            self.s3.eq(0),
             self.s4.eq(ClockSignal("other")),
             self.s5.eq(ResetSignal("other")),
+        )
+        f.add_statements(
+            "sync",
+            self.s3.eq(0),
         )
         f.add_driver(self.s1, None)
         f.add_driver(self.s2, None)
         f.add_driver(self.s3, "sync")
 
         f = DomainRenamer("pix")(f)
-        self.assertRepr(f.statements, """
+        self.assertRepr(f.statements[None], """
         (
             (eq (sig s1) (clk pix))
             (eq (rst pix) (sig s2))
-            (eq (sig s3) (const 1'd0))
             (eq (sig s4) (clk other))
             (eq (sig s5) (rst other))
         )
         """)
+        self.assertRepr(f.statements["pix"], """
+        (
+            (eq (sig s3) (const 1'd0))
+        )
+        """)
+        self.assertFalse("sync" in f.statements)
         self.assertEqual(f.drivers, {
             None: SignalSet((self.s1, self.s2)),
             "pix": SignalSet((self.s3,)),
@@ -54,12 +63,13 @@ class DomainRenamerTestCase(FHDLTestCase):
     def test_rename_multi(self):
         f = Fragment()
         f.add_statements(
+            None,
             self.s1.eq(ClockSignal()),
             self.s2.eq(ResetSignal("other")),
         )
 
         f = DomainRenamer({"sync": "pix", "other": "pix2"})(f)
-        self.assertRepr(f.statements, """
+        self.assertRepr(f.statements[None], """
         (
             (eq (sig s1) (clk pix))
             (eq (sig s2) (rst pix2))
@@ -86,12 +96,13 @@ class DomainRenamerTestCase(FHDLTestCase):
         f = Fragment()
         f.add_domains(cd_pix)
         f.add_statements(
+            None,
             self.s1.eq(ResetSignal(allow_reset_less=True)),
         )
 
         f = DomainRenamer("pix")(f)
         f = DomainLowerer()(f)
-        self.assertRepr(f.statements, """
+        self.assertRepr(f.statements[None], """
         (
             (eq (sig s1) (const 1'd0))
         )
@@ -151,11 +162,12 @@ class DomainLowererTestCase(FHDLTestCase):
         f = Fragment()
         f.add_domains(sync)
         f.add_statements(
+            None,
             self.s.eq(ClockSignal("sync"))
         )
 
         f = DomainLowerer()(f)
-        self.assertRepr(f.statements, """
+        self.assertRepr(f.statements[None], """
         (
             (eq (sig s) (sig clk))
         )
@@ -166,11 +178,12 @@ class DomainLowererTestCase(FHDLTestCase):
         f = Fragment()
         f.add_domains(sync)
         f.add_statements(
+            None,
             self.s.eq(ResetSignal("sync"))
         )
 
         f = DomainLowerer()(f)
-        self.assertRepr(f.statements, """
+        self.assertRepr(f.statements[None], """
         (
             (eq (sig s) (sig rst))
         )
@@ -181,11 +194,12 @@ class DomainLowererTestCase(FHDLTestCase):
         f = Fragment()
         f.add_domains(sync)
         f.add_statements(
+            None,
             self.s.eq(ResetSignal("sync", allow_reset_less=True))
         )
 
         f = DomainLowerer()(f)
-        self.assertRepr(f.statements, """
+        self.assertRepr(f.statements[None], """
         (
             (eq (sig s) (const 1'd0))
         )
@@ -208,6 +222,7 @@ class DomainLowererTestCase(FHDLTestCase):
     def test_lower_wrong_domain(self):
         f = Fragment()
         f.add_statements(
+            None,
             self.s.eq(ClockSignal("xxx"))
         )
 
@@ -220,6 +235,7 @@ class DomainLowererTestCase(FHDLTestCase):
         f = Fragment()
         f.add_domains(sync)
         f.add_statements(
+            None,
             self.s.eq(ResetSignal("sync"))
         )
 
@@ -368,12 +384,13 @@ class ResetInserterTestCase(FHDLTestCase):
     def test_reset_default(self):
         f = Fragment()
         f.add_statements(
+            "sync",
             self.s1.eq(1)
         )
         f.add_driver(self.s1, "sync")
 
         f = ResetInserter(self.c1)(f)
-        self.assertRepr(f.statements, """
+        self.assertRepr(f.statements["sync"], """
         (
             (eq (sig s1) (const 1'd1))
             (switch (sig c1)
@@ -384,18 +401,20 @@ class ResetInserterTestCase(FHDLTestCase):
 
     def test_reset_cd(self):
         f = Fragment()
-        f.add_statements(
-            self.s1.eq(1),
-            self.s2.eq(0),
-        )
+        f.add_statements("sync", self.s1.eq(1))
+        f.add_statements("pix", self.s2.eq(0))
         f.add_domains(ClockDomain("sync"))
         f.add_driver(self.s1, "sync")
         f.add_driver(self.s2, "pix")
 
         f = ResetInserter({"pix": self.c1})(f)
-        self.assertRepr(f.statements, """
+        self.assertRepr(f.statements["sync"], """
         (
             (eq (sig s1) (const 1'd1))
+        )
+        """)
+        self.assertRepr(f.statements["pix"], """
+        (
             (eq (sig s2) (const 1'd0))
             (switch (sig c1)
                 (case 1 (eq (sig s2) (const 1'd1)))
@@ -405,13 +424,11 @@ class ResetInserterTestCase(FHDLTestCase):
 
     def test_reset_value(self):
         f = Fragment()
-        f.add_statements(
-            self.s2.eq(0)
-        )
+        f.add_statements("sync", self.s2.eq(0))
         f.add_driver(self.s2, "sync")
 
         f = ResetInserter(self.c1)(f)
-        self.assertRepr(f.statements, """
+        self.assertRepr(f.statements["sync"], """
         (
             (eq (sig s2) (const 1'd0))
             (switch (sig c1)
@@ -422,13 +439,11 @@ class ResetInserterTestCase(FHDLTestCase):
 
     def test_reset_less(self):
         f = Fragment()
-        f.add_statements(
-            self.s3.eq(0)
-        )
+        f.add_statements("sync", self.s3.eq(0))
         f.add_driver(self.s3, "sync")
 
         f = ResetInserter(self.c1)(f)
-        self.assertRepr(f.statements, """
+        self.assertRepr(f.statements["sync"], """
         (
             (eq (sig s3) (const 1'd0))
             (switch (sig c1)
@@ -447,13 +462,11 @@ class EnableInserterTestCase(FHDLTestCase):
 
     def test_enable_default(self):
         f = Fragment()
-        f.add_statements(
-            self.s1.eq(1)
-        )
+        f.add_statements("sync", self.s1.eq(1))
         f.add_driver(self.s1, "sync")
 
         f = EnableInserter(self.c1)(f)
-        self.assertRepr(f.statements, """
+        self.assertRepr(f.statements["sync"], """
         (
             (eq (sig s1) (const 1'd1))
             (switch (sig c1)
@@ -464,17 +477,19 @@ class EnableInserterTestCase(FHDLTestCase):
 
     def test_enable_cd(self):
         f = Fragment()
-        f.add_statements(
-            self.s1.eq(1),
-            self.s2.eq(0),
-        )
+        f.add_statements("sync", self.s1.eq(1))
+        f.add_statements("pix", self.s2.eq(0))
         f.add_driver(self.s1, "sync")
         f.add_driver(self.s2, "pix")
 
         f = EnableInserter({"pix": self.c1})(f)
-        self.assertRepr(f.statements, """
+        self.assertRepr(f.statements["sync"], """
         (
             (eq (sig s1) (const 1'd1))
+        )
+        """)
+        self.assertRepr(f.statements["pix"], """
+        (
             (eq (sig s2) (const 1'd0))
             (switch (sig c1)
                 (case 0 (eq (sig s2) (sig s2)))
@@ -484,21 +499,17 @@ class EnableInserterTestCase(FHDLTestCase):
 
     def test_enable_subfragment(self):
         f1 = Fragment()
-        f1.add_statements(
-            self.s1.eq(1)
-        )
+        f1.add_statements("sync", self.s1.eq(1))
         f1.add_driver(self.s1, "sync")
 
         f2 = Fragment()
-        f2.add_statements(
-            self.s2.eq(1)
-        )
+        f2.add_statements("sync", self.s2.eq(1))
         f2.add_driver(self.s2, "sync")
         f1.add_subfragment(f2)
 
         f1 = EnableInserter(self.c1)(f1)
         (f2, _), = f1.subfragments
-        self.assertRepr(f1.statements, """
+        self.assertRepr(f1.statements["sync"], """
         (
             (eq (sig s1) (const 1'd1))
             (switch (sig c1)
@@ -506,7 +517,7 @@ class EnableInserterTestCase(FHDLTestCase):
             )
         )
         """)
-        self.assertRepr(f2.statements, """
+        self.assertRepr(f2.statements["sync"], """
         (
             (eq (sig s2) (const 1'd1))
             (switch (sig c1)
@@ -542,9 +553,7 @@ class _MockElaboratable(Elaboratable):
 
     def elaborate(self, platform):
         f = Fragment()
-        f.add_statements(
-            self.s1.eq(1)
-        )
+        f.add_statements("sync", self.s1.eq(1))
         f.add_driver(self.s1, "sync")
         return f
 
@@ -569,7 +578,7 @@ class TransformedElaboratableTestCase(FHDLTestCase):
         self.assertIs(te1, te2)
 
         f = Fragment.get(te2, None)
-        self.assertRepr(f.statements, """
+        self.assertRepr(f.statements["sync"], """
         (
             (eq (sig s1) (const 1'd1))
             (switch (sig c1)

--- a/tests/test_lib_wiring.py
+++ b/tests/test_lib_wiring.py
@@ -889,7 +889,7 @@ class ConnectTestCase(unittest.TestCase):
 
         m = Module()
         connect(m, src=src, snk=snk)
-        self.assertEqual([repr(stmt) for stmt in m._statements], [
+        self.assertEqual([repr(stmt) for stmt in m._statements[None]], [
             '(eq (sig snk__addr) (sig src__addr))',
             '(eq (sig snk__cycle) (sig src__cycle))',
             '(eq (sig src__r_data) (sig snk__r_data))',
@@ -903,7 +903,7 @@ class ConnectTestCase(unittest.TestCase):
                      a=Const(1)),
                 q=NS(signature=Signature({"a": In(1)}),
                      a=Const(1)))
-        self.assertEqual(m._statements, [])
+        self.assertEqual(m._statements, {})
 
     def test_nested(self):
         m = Module()
@@ -912,7 +912,7 @@ class ConnectTestCase(unittest.TestCase):
                      a=NS(signature=Signature({"f": Out(1)}), f=Signal(name='p__a'))),
                 q=NS(signature=Signature({"a": In(Signature({"f": Out(1)}))}),
                      a=NS(signature=Signature({"f": Out(1)}).flip(), f=Signal(name='q__a'))))
-        self.assertEqual([repr(stmt) for stmt in m._statements], [
+        self.assertEqual([repr(stmt) for stmt in m._statements[None]], [
             '(eq (sig q__a) (sig p__a))'
         ])
 
@@ -931,7 +931,7 @@ class ConnectTestCase(unittest.TestCase):
                           g=Signal(name="q__b__g"),
                           f=Signal(name="q__b__f")),
                      a=Signal(name="q__a")))
-        self.assertEqual([repr(stmt) for stmt in m._statements], [
+        self.assertEqual([repr(stmt) for stmt in m._statements[None]], [
             '(eq (sig q__a) (sig p__a))',
             '(eq (sig q__b__f) (sig p__b__f))',
             '(eq (sig q__b__g) (sig p__b__g))',
@@ -942,7 +942,7 @@ class ConnectTestCase(unittest.TestCase):
 
         m = Module()
         connect(m, p=sig.create(path=('p',)), q=sig.flip().create(path=('q',)))
-        self.assertEqual([repr(stmt) for stmt in m._statements], [
+        self.assertEqual([repr(stmt) for stmt in m._statements[None]], [
             '(eq (sig q__a__0) (sig p__a__0))',
             '(eq (sig q__a__1) (sig p__a__1))'
         ])
@@ -952,7 +952,7 @@ class ConnectTestCase(unittest.TestCase):
 
         m = Module()
         connect(m, p=sig.create(path=('p',)), q=sig.flip().create(path=('q',)))
-        self.assertEqual([repr(stmt) for stmt in m._statements], [
+        self.assertEqual([repr(stmt) for stmt in m._statements[None]], [
             '(eq (sig q__a__0__0) (sig p__a__0__0))',
         ])
 

--- a/tests/test_sim.py
+++ b/tests/test_sim.py
@@ -27,7 +27,7 @@ class SimulatorUnitTestCase(FHDLTestCase):
 
         stmt = stmt(osig, *isigs)
         frag = Fragment()
-        frag.add_statements(stmt)
+        frag.add_statements(None, stmt)
         for signal in flatten(s._lhs_signals() for s in Statement.cast(stmt)):
             frag.add_driver(signal)
 
@@ -1045,9 +1045,10 @@ class SimulatorRegressionTestCase(FHDLTestCase):
 
     def test_bug_595(self):
         dut = Module()
+        dummy = Signal()
         with dut.FSM(name="name with space"):
             with dut.State(0):
-                pass
+                dut.d.comb += dummy.eq(1)
         sim = Simulator(dut)
         with self.assertRaisesRegex(NameError,
                 r"^Signal 'bench\.top\.name with space_state' contains a whitespace character$"):


### PR DESCRIPTION
Fixes #1079.

This does not remove `Fragment.drivers` — that will be done when the new IR lands and the remaining uses in `hdl._ir` can be killed.

This also does not remove the special signals inside `Property` — they are still used within RTLIL backend, and likewise will be removed when the new IR lands.