### PR TITLE
Remove `ValueKey`, `ValueDict`, `ValueSet`

### DIFF
--- a/amaranth/hdl/ast.py
+++ b/amaranth/hdl/ast.py
@@ -13,7 +13,7 @@ __all__ = [
     "Initial",
     "Statement", "Switch",
     "Property", "Assign", "Assert", "Assume", "Cover",
-    "ValueKey", "ValueDict", "ValueSet", "SignalKey", "SignalDict", "SignalSet",
+    "SignalKey", "SignalDict", "SignalSet",
 ]
 
 


### PR DESCRIPTION
These aren't used internally anymore and haven't been used in any code published on GitHub, so they are simply removed rather than deprecated.