### PR TITLE
Add reference documentation for `Value`, `ValueCastable`, `ValueLike`

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -885,12 +885,12 @@ Assigning to signals
 Similar to :ref:`how Amaranth operators work <lang-abstractexpr>`, an Amaranth assignment is an ordinary Python object used to describe a part of a circuit. An assignment does not have any effect on the signal it changes until it is added to a control domain in a module. Once added, it introduces logic into the circuit generated from that module.
 
 
-.. _lang-assignlhs:
+.. _lang-assignable:
 
-Assignment targets
-------------------
+Assignable values
+-----------------
 
-The target of an assignment can be more complex than a single signal. It is possible to assign to any combination of signals, :ref:`bit slices <lang-seqops>`, :ref:`concatenations <lang-seqops>`, :ref:`part selects <lang-seqops>`, and :ref:`array proxy objects <lang-array>` as long as it includes no other values:
+An assignment can affect a value that is more complex than just a signal. It is possible to assign to any combination of :ref:`signals <lang-signals>`, :ref:`bit slices <lang-seqops>`, :ref:`concatenations <lang-seqops>`, :ref:`part selects <lang-seqops>`, and :ref:`array proxy objects <lang-array>` as long as it includes no other values:
 
 .. doctest::
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -101,5 +101,16 @@ See also the introduction to :ref:`shapes <lang-shapes>` and :ref:`casting from 
 .. autoclass:: Shape
 .. autofunction:: unsigned
 .. autofunction:: signed
-.. autoclass:: ShapeCastable
-.. autoclass:: ShapeLike
+.. autoclass:: ShapeCastable()
+.. autoclass:: ShapeLike()
+
+
+Values
+======
+
+See also the introduction to :ref:`values <lang-values>` and :ref:`casting from value-like objects <lang-valuelike>` in the language guide.
+
+.. autoclass:: Value
+    :special-members: __bool__, __pos__, __neg__, __add__, __radd__, __sub__, __rsub__, __mul__, __rmul__, __mod__, __rmod__, __floordiv__, __rfloordiv__, __eq__, __ne__, __lt__, __le__, __gt__, __ge__, __abs__, __invert__, __and__, __rand__, __or__, __ror__, __xor__, __rxor__, __lshift__, __rlshift__, __rshift__, __rrshift__, __len__, __getitem__, __contains__, __hash__
+.. autoclass:: ValueCastable()
+.. autoclass:: ValueLike()

--- a/tests/test_hdl_ast.py
+++ b/tests/test_hdl_ast.py
@@ -1350,8 +1350,8 @@ class MockValueCastableCustomGetattr(ValueCastable):
 class ValueCastableTestCase(FHDLTestCase):
     def test_not_decorated(self):
         with self.assertRaisesRegex(TypeError,
-                r"^Class 'MockValueCastableNotDecorated' deriving from `ValueCastable` must "
-                r"decorate the `as_value` method with the `ValueCastable.lowermethod` decorator$"):
+                r"^Class 'MockValueCastableNotDecorated' deriving from 'ValueCastable' must "
+                r"decorate the 'as_value' method with the 'ValueCastable.lowermethod' decorator$"):
             class MockValueCastableNotDecorated(ValueCastable):
                 def __init__(self):
                     pass
@@ -1364,15 +1364,15 @@ class ValueCastableTestCase(FHDLTestCase):
 
     def test_no_override(self):
         with self.assertRaisesRegex(TypeError,
-                r"^Class 'MockValueCastableNoOverrideAsValue' deriving from `ValueCastable` must "
-                r"override the `as_value` method$"):
+                r"^Class 'MockValueCastableNoOverrideAsValue' deriving from 'ValueCastable' must "
+                r"override the 'as_value' method$"):
             class MockValueCastableNoOverrideAsValue(ValueCastable):
                 def __init__(self):
                     pass
 
         with self.assertRaisesRegex(TypeError,
-                r"^Class 'MockValueCastableNoOverrideShapec' deriving from `ValueCastable` must "
-                r"override the `shape` method$"):
+                r"^Class 'MockValueCastableNoOverrideShapec' deriving from 'ValueCastable' must "
+                r"override the 'shape' method$"):
             class MockValueCastableNoOverrideShapec(ValueCastable):
                 def __init__(self):
                     pass


### PR DESCRIPTION
Except `Value.matches`, `Value.__getitem__`, and `Value.implies`.