### PR TITLE
Require Yosys 0.38

### DIFF
--- a/amaranth/back/verilog.py
+++ b/amaranth/back/verilog.py
@@ -9,9 +9,7 @@ __all__ = ["YosysError", "convert", "convert_fragment"]
 
 def _convert_rtlil_text(rtlil_text, *, strip_internal_attrs=False, write_verilog_opts=()):
     # this version requirement needs to be synchronized with the one in pyproject.toml!
-    # Yosys 0.37 has a critical miscompilation in Verilog backend:
-    # https://github.com/amaranth-lang/amaranth/issues/1049
-    yosys = find_yosys(lambda ver: ver >= (0, 35) and not (0, 36, 79) <= ver <= (0, 37, 29))
+    yosys = find_yosys(lambda ver: ver >= (0, 38))
 
     script = []
     script.append(f"read_ilang <<rtlil\n{rtlil_text}\nrtlil")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 
 [project.optional-dependencies]
 # this version requirement needs to be synchronized with the one in amaranth.back.verilog!
-builtin-yosys = ["amaranth-yosys>=0.35,!=0.37.0.*"]
+builtin-yosys = ["amaranth-yosys>=0.38"]
 remote-build  = ["paramiko~=2.7"]
 
 [project.scripts]


### PR DESCRIPTION
This avoids the awkward requirement due to the bug in Yosys 0.37, and will soon be required anyway once the `$check` cell is emitted.