### PR TITLE
Require Yosys 0.38 [0.4 backport]

### DIFF
--- a/amaranth/back/verilog.py
+++ b/amaranth/back/verilog.py
@@ -9,7 +9,7 @@ __all__ = ["YosysError", "convert", "convert_fragment"]
 
 def _convert_rtlil_text(rtlil_text, *, strip_internal_attrs=False, write_verilog_opts=()):
     # this version requirement needs to be synchronized with the one in pyproject.toml!
-    yosys = find_yosys(lambda ver: ver >= (0, 35))
+    yosys = find_yosys(lambda ver: ver >= (0, 38))
 
     script = []
     script.append(f"read_ilang <<rtlil\n{rtlil_text}\nrtlil")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 
 [project.optional-dependencies]
 # this version requirement needs to be synchronized with the one in amaranth.back.verilog!
-builtin-yosys = ["amaranth-yosys>=0.35"]
+builtin-yosys = ["amaranth-yosys>=0.38"]
 remote-build  = ["paramiko~=2.7"]
 
 [project.scripts]


### PR DESCRIPTION
This avoids the Verilog backend bug in Yosys 0.37.