### PR TITLE
hdl._dsl: fix using 0-width `Switch` with integer keys. [0.4 backport]

### DIFF
--- a/amaranth/hdl/dsl.py
+++ b/amaranth/hdl/dsl.py
@@ -331,6 +331,8 @@ class Module(_ModuleBuilderRoot, Elaboratable):
                                       "expression, not {!r}"
                                       .format(pattern)) from e
                 pattern_len = bits_for(pattern.value)
+                if pattern.value == 0:
+                    pattern_len = 0
                 if pattern_len > len(switch_data["test"]):
                     warnings.warn("Case pattern '{!r}' ({}'{:b}) is wider than switch value "
                                   "(which has width {}); comparison will never be true"

--- a/tests/test_hdl_dsl.py
+++ b/tests/test_hdl_dsl.py
@@ -494,6 +494,21 @@ class DSLTestCase(FHDLTestCase):
         )
         """)
 
+    def test_Switch_zero_width(self):
+        m = Module()
+        s = Signal(0)
+        with m.Switch(s):
+            with m.Case(0):
+                m.d.comb += self.c1.eq(1)
+        m._flush()
+        self.assertRepr(m._statements, """
+        (
+            (switch (sig s)
+                (case (eq (sig c1) (const 1'd1)))
+            )
+        )
+        """)
+
     def test_Case_bits_wrong(self):
         m = Module()
         with m.Switch(self.w1):


### PR DESCRIPTION
Depends on #1137.