### PR TITLE
sim.pysim: Only close VCD/GTKW files if we opened them ourselves.

### DIFF
--- a/amaranth/sim/pysim.py
+++ b/amaranth/sim/pysim.py
@@ -41,10 +41,14 @@ class _VCDWriter:
         # the simulator is still usable if it's not installed for some reason.
         import vcd, vcd.gtkw
 
+        self.close_vcd = False
+        self.close_gtkw = False
         if isinstance(vcd_file, str):
             vcd_file = open(vcd_file, "w")
+            self.close_vcd = True
         if isinstance(gtkw_file, str):
             gtkw_file = open(gtkw_file, "w")
+            self.close_gtkw = True
 
         self.vcd_signal_vars = SignalDict()
         self.vcd_memory_vars = {}
@@ -189,9 +193,9 @@ class _VCDWriter:
                 else:
                     assert False # :nocov:
 
-        if self.vcd_file is not None:
+        if self.close_vcd:
             self.vcd_file.close()
-        if self.gtkw_file is not None:
+        if self.close_gtkw:
             self.gtkw_file.close()
 
 


### PR DESCRIPTION
Fixes #1107.