### PR TITLE
lib.io: Make `Pin.name` return the whole path.

### DIFF
--- a/amaranth/lib/io.py
+++ b/amaranth/lib/io.py
@@ -131,7 +131,7 @@ class Pin(wiring.PureInterface):
             name = tracer.get_var_name(depth=2 + src_loc_at, default="$pin")
             path = (name,)
         self.path = tuple(path)
-        self.name = path[-1]
+        self.name = "__".join(path)
         signature = Pin.Signature(width, dir, xdr=xdr)
         super().__init__(signature, path=path, src_loc_at=src_loc_at + 1)
 

--- a/tests/test_lib_io.py
+++ b/tests/test_lib_io.py
@@ -226,6 +226,6 @@ class PinTestCase(FHDLTestCase):
         self.assertEqual(pin.path, ("testpin",))
         self.assertEqual(pin.i0.name, "testpin__i0")
         pin = Pin(2, dir="io", xdr=2, path=["a", "b"])
-        self.assertEqual(pin.name, "b")
+        self.assertEqual(pin.name, "a__b")
         self.assertEqual(pin.path, ("a", "b"))
         self.assertEqual(pin.i0.name, "a__b__i0")


### PR DESCRIPTION
This prevents duplicate pin names.