### PR TITLE
Some f-strings in utils.py are broken (missing the letter "f")

### DIFF
--- a/amaranth/utils.py
+++ b/amaranth/utils.py
@@ -13,7 +13,7 @@ def ceil_log2(n):
     """
     n = operator.index(n)
     if n < 0:
-        raise ValueError("{n} is negative")
+        raise ValueError(f"{n} is negative")
     if n == 0:
         return 0
     return (n - 1).bit_length()
@@ -26,7 +26,7 @@ def exact_log2(n):
     """
     n = operator.index(n)
     if n <= 0 or (n & (n - 1)):
-        raise ValueError("{n} is not a power of 2")
+        raise ValueError(f"{n} is not a power of 2")
     return (n - 1).bit_length()
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,7 +16,7 @@ class Log2TestCase(unittest.TestCase):
         self.assertEqual(ceil_log2(9), 4)
         with self.assertRaises(TypeError):
             ceil_log2(1.5)
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, r"^-1 is negative$"):
             ceil_log2(-1)
 
     def test_exact_log2(self):
@@ -25,7 +25,7 @@ class Log2TestCase(unittest.TestCase):
         self.assertEqual(exact_log2(4), 2)
         self.assertEqual(exact_log2(8), 3)
         for val in [-1, 0, 3, 5, 6, 7, 9]:
-            with self.assertRaises(ValueError):
+            with self.assertRaisesRegex(ValueError, (f"^{val} is not a power of 2$")):
                 exact_log2(val)
         with self.assertRaises(TypeError):
             exact_log2(1.5)


### PR DESCRIPTION
Without this patch, `exact_log2(3)` will print `"{n} is not a power of 2"` instead of `"3 is not a power of 2"` as intended