### PR TITLE
lib.memory: Allow setting `Memory.init`.

### DIFF
--- a/amaranth/lib/memory.py
+++ b/amaranth/lib/memory.py
@@ -408,6 +408,10 @@ class Memory(wiring.Component):
     def init(self):
         return self._init
 
+    @init.setter
+    def init(self, init):
+        self._init = Memory.Init(init, shape=self._shape, depth=self._depth)
+
     @property
     def attrs(self):
         return self._attrs

--- a/tests/test_lib_memory.py
+++ b/tests/test_lib_memory.py
@@ -311,6 +311,8 @@ class MemoryTestCase(FHDLTestCase):
         self.assertEqual(m.init._raw, [0, 2, 0, 0])
         m.init[2:] = [4, 5]
         self.assertEqual(list(m.init), [0, 2, 4, 5])
+        m.init = [6, 7]
+        self.assertEqual(list(m.init), [6, 7, 0, 0])
 
     def test_init_set_shapecastable(self):
         m = Memory(shape=MyStruct, depth=4, init=[])


### PR DESCRIPTION
The `init` property is already mutable, so this adds no actual new functionality, just convenience.