### PR TITLE
lib.wiring: remove unnecessary flipping in `Signature.flatten`

### DIFF
--- a/amaranth/lib/wiring.py
+++ b/amaranth/lib/wiring.py
@@ -798,8 +798,6 @@ class Signature(metaclass=SignatureMeta):
                     yield path, Member(member.flow, member.shape, init=member.init), value
                 elif member.is_signature:
                     for sub_path, sub_member, sub_value in member.signature.flatten(value):
-                        if member.flow == In:
-                            sub_member = sub_member.flip()
                         yield ((*path, *sub_path), sub_member, sub_value)
                 else:
                     assert False # :nocov:

--- a/tests/test_lib_wiring.py
+++ b/tests/test_lib_wiring.py
@@ -373,8 +373,8 @@ class SignatureTestCase(unittest.TestCase):
         self.assertFlattenedSignature(sig.flatten(intf), [
             (("a", "p"), Out(1), intf.a.p),
             (("b", "q"), In (1), intf.b.q),
-            (("c", "r"), Out(1), intf.c.r),
-            (("d", "s"), In (1), intf.d.s),
+            (("c", "r"), In (1), intf.c.r),
+            (("d", "s"), Out(1), intf.d.s),
         ])
 
     def test_is_compliant_signature(self):


### PR DESCRIPTION
The nested signature is already flipped, which means that its `flatten` method has performed the flipping on member flows already.