### PR TITLE
Dump simulation testbench commands as VCD waveforms

### DIFF
--- a/amaranth/sim/_pycoro.py
+++ b/amaranth/sim/_pycoro.py
@@ -12,12 +12,14 @@ __all__ = ["PyCoroProcess"]
 
 
 class PyCoroProcess(BaseProcess):
-    def __init__(self, state, domains, constructor, *, default_cmd=None, testbench=False):
+    def __init__(self, state, domains, constructor, *, default_cmd=None, testbench=False,
+                 on_command=None):
         self.state = state
         self.domains = domains
         self.constructor = constructor
         self.default_cmd = default_cmd
         self.testbench = testbench
+        self.on_command = on_command
 
         self.reset()
 
@@ -78,6 +80,9 @@ class PyCoroProcess(BaseProcess):
                     command = self.default_cmd
                 response = None
                 exception = None
+
+                if self.on_command is not None:
+                    self.on_command(self, command)
 
                 if isinstance(command, ValueCastable):
                     command = Value.cast(command)

--- a/tests/test_sim.py
+++ b/tests/test_sim.py
@@ -1191,6 +1191,15 @@ class SimulatorIntegrationTestCase(FHDLTestCase):
         with sim.write_vcd("test.vcd", fs_per_delta=1):
             sim.run()
 
+    def test_process_name_collision(self):
+        def testbench():
+            yield Passive()
+        sim = Simulator(Module())
+        sim.add_testbench(testbench)
+        sim.add_testbench(testbench)
+        with sim.write_vcd("test.vcd", fs_per_delta=1):
+            sim.run()
+
 
 class SimulatorRegressionTestCase(FHDLTestCase):
     def test_bug_325(self):


### PR DESCRIPTION
If delta cycles are expanded (i.e. if the `fs_per_delta` argument to `Simulator.write_vcd` is not zero), then create a string typed variable for each testbench in the simulation, which reflects the current command being executed by that testbench. To make all commands visible, insert a (visual) delta cycle after each executed command, and ensure that there is a change/crossing point in the waveform display each time a command is executed, even if several identical ones in a row.

If delta cycles are not expanded, the behavior is unchanged.

Here is an example of a simulation where two testbenches are racing against each other. In the two screenshots, the testbenches are added in different order.

![Screenshot 1](https://github.com/amaranth-lang/amaranth/assets/54771/d0e48404-f941-4ab2-b2c8-2d82d69c5a21)

![Screenshot 2](https://github.com/amaranth-lang/amaranth/assets/54771/6c3f508a-a375-423d-a238-84b86a8c55e2)

---

- Depends on https://github.com/amaranth-lang/amaranth/pull/1232