### PR TITLE
hdl._ast: fix `_value_repr` computation.

### DIFF
--- a/amaranth/hdl/_repr.py
+++ b/amaranth/hdl/_repr.py
@@ -14,6 +14,9 @@ class FormatInt(Format):
     def format(self, value):
         return f"{value:d}"
 
+    def __repr__(self):
+        return f"FormatInt()"
+
 
 class FormatEnum(Format):
     def __init__(self, enum):
@@ -25,6 +28,9 @@ class FormatEnum(Format):
         except ValueError:
             return f"?/{value:d}"
 
+    def __repr__(self):
+        return f"FormatEnum({self.enum.__name__})"
+
 
 class FormatCustom(Format):
     def __init__(self, formatter):
@@ -32,6 +38,9 @@ class FormatCustom(Format):
 
     def format(self, value):
         return self.formatter(value)
+
+    def __repr__(self):
+        return f"FormatCustom({self.formatter})"
 
 
 class Repr:
@@ -44,3 +53,6 @@ class Repr:
         self.format = format
         self.value  = value
         self.path   = path
+
+    def __repr__(self):
+        return f"Repr({self.format!r}, {self.value!r}, {self.path!r})"

--- a/tests/test_hdl_ast.py
+++ b/tests/test_hdl_ast.py
@@ -1321,6 +1321,7 @@ class SignalTestCase(FHDLTestCase):
         s = Signal(decoder=Color)
         self.assertEqual(s.decoder(1), "RED/1")
         self.assertEqual(s.decoder(3), "3")
+        self.assertRepr(s._value_repr, "(Repr(FormatEnum(Color), (sig s), ()),)")
 
     def test_enum(self):
         s1 = Signal(UnsignedEnum)
@@ -1328,12 +1329,17 @@ class SignalTestCase(FHDLTestCase):
         s2 = Signal(SignedEnum)
         self.assertEqual(s2.shape(), signed(2))
         self.assertEqual(s2.decoder(SignedEnum.FOO), "FOO/-1")
+        self.assertRepr(s2._value_repr, "(Repr(FormatEnum(SignedEnum), (sig s2), ()),)")
 
     def test_const_wrong(self):
         s1 = Signal()
         with self.assertRaisesRegex(TypeError,
                 r"^Value \(sig s1\) cannot be converted to an Amaranth constant$"):
             Const.cast(s1)
+
+    def test_value_repr(self):
+        s = Signal()
+        self.assertRepr(s._value_repr, "(Repr(FormatInt(), (sig s), ()),)")
 
 
 class ClockSignalTestCase(FHDLTestCase):

--- a/tests/test_lib_data.py
+++ b/tests/test_lib_data.py
@@ -458,6 +458,11 @@ class ViewTestCase(FHDLTestCase):
         self.assertIsInstance(cv, Signal)
         self.assertEqual(cv.shape(), unsigned(3))
         self.assertEqual(cv.name, "v")
+        self.assertRepr(cv._value_repr, """
+        (Repr(FormatInt(), (sig v), ()),
+            Repr(FormatInt(), (slice (sig v) 0:1), ('a',)),
+            Repr(FormatInt(), (slice (sig v) 1:3), ('b',)))
+        """)
 
     def test_construct_signal_init(self):
         v1 = Signal(data.StructLayout({"a": unsigned(1), "b": unsigned(2)}),

--- a/tests/test_lib_enum.py
+++ b/tests/test_lib_enum.py
@@ -137,6 +137,7 @@ class EnumTestCase(FHDLTestCase):
             B = -3
         a = Signal(EnumA)
         self.assertRepr(a, "(sig a)")
+        self.assertRepr(a._value_repr, "(Repr(FormatEnum(EnumA), (sig a), ()),)")
 
     def test_enum_view(self):
         class EnumA(Enum, shape=signed(4)):


### PR DESCRIPTION
Fixes fallout from #1165.