### PR TITLE
Emit signal groups in GTKW files

### DIFF
--- a/amaranth/sim/core.py
+++ b/amaranth/sim/core.py
@@ -210,17 +210,25 @@ class Simulator:
                     file.close()
             raise ValueError("Cannot start writing waveforms after advancing simulation time")
 
-        for trace in traces:
-            if isinstance(trace, ValueLike):
-                trace_cast = Value.cast(trace)
+        def traverse_traces(traces):
+            if isinstance(traces, ValueLike):
+                trace_cast = Value.cast(traces)
                 if isinstance(trace_cast, MemoryData._Row):
-                    continue
+                    return
                 for trace_signal in trace_cast._rhs_signals():
                     if trace_signal.name == "":
-                        if trace_signal is trace:
+                        if trace_signal is traces:
                             raise TypeError("Cannot trace signal with private name")
                         else:
-                            raise TypeError(f"Cannot trace signal with private name (within {trace!r})")
+                            raise TypeError(f"Cannot trace signal with private name (within {traces!r})")
+            elif isinstance(traces, (list, tuple)):
+                for trace in traces:
+                    traverse_traces(trace)
+            elif isinstance(traces, dict):
+                for trace in traces.values():
+                    traverse_traces(trace)
+
+        traverse_traces(traces)
 
         return self._engine.write_vcd(vcd_file=vcd_file, gtkw_file=gtkw_file,
                                       traces=traces, fs_per_delta=fs_per_delta)

--- a/tests/test_sim.py
+++ b/tests/test_sim.py
@@ -16,7 +16,7 @@ from amaranth.hdl._ir import *
 from amaranth.sim import *
 from amaranth.sim._pyeval import eval_format
 from amaranth.lib.memory import Memory
-from amaranth.lib import enum, data
+from amaranth.lib import enum, data, wiring
 
 from .utils import *
 from amaranth._utils import _ignore_deprecated
@@ -1373,6 +1373,49 @@ class SimulatorIntegrationTestCase(FHDLTestCase):
 
         with self.assertSimulation(Module(), traces=[mem1, mem2, mem3]) as sim:
             sim.add_testbench(testbench)
+
+
+class SimulatorTracesTestCase(FHDLTestCase):
+    def assertDef(self, traces, flat_traces):
+        frag = Fragment()
+
+        def process():
+            yield Delay(1e-6)
+
+        sim = Simulator(frag)
+        sim.add_testbench(process)
+        with sim.write_vcd("test.vcd", "test.gtkw", traces=traces):
+            sim.run()
+
+    def test_signal(self):
+        a = Signal()
+        self.assertDef(a, [a])
+
+    def test_list(self):
+        a = Signal()
+        self.assertDef([a], [a])
+
+    def test_tuple(self):
+        a = Signal()
+        self.assertDef((a,), [a])
+
+    def test_dict(self):
+        a = Signal()
+        self.assertDef({"a": a}, [a])
+
+    def test_struct_view(self):
+        a = Signal(data.StructLayout({"a": 1, "b": 3}))
+        self.assertDef(a, [a])
+
+    def test_interface(self):
+        sig = wiring.Signature({
+            "a": wiring.In(1),
+            "b": wiring.Out(3),
+            "c": wiring.Out(2).array(4),
+            "d": wiring.In(wiring.Signature({"e": wiring.In(5)}))
+        })
+        a = sig.create()
+        self.assertDef(a, [a])
 
 
 class SimulatorRegressionTestCase(FHDLTestCase):


### PR DESCRIPTION
Fixes #764.

Things to look at in the review:
* Group names for views and interfaces. The current code uses "view" and "interface". Maybe the name should reference a layout/signature in some way?
* Treating single-field view as in https://github.com/amaranth-lang/amaranth/issues/764#issuecomment-2014220740 is not implemented. It could be implemented by adding a special case.
* I've added tests that check if the code doesn't raise an exception, the resulting gtkw files are not checked. I'm not sure how to best check them; I could compare them with a reference, but this would freeze the signal naming. Is signal naming for views and interfaces specified?
* Had to add another change related to the recent private names commit. Now that there are three separate recursive functions in this PR, maybe the recursion pattern should be abstracted away?