### PR TITLE
hdl._ir: rename `Instance.named_ports` to `Instance.ports`.

### DIFF
--- a/amaranth/hdl/_xfrm.py
+++ b/amaranth/hdl/_xfrm.py
@@ -232,15 +232,15 @@ class FragmentTransformer:
         for subfragment, name, src_loc in fragment.subfragments:
             new_fragment.add_subfragment(self(subfragment), name, src_loc=src_loc)
 
-    def map_named_ports(self, fragment, new_fragment):
+    def map_ports(self, fragment, new_fragment):
         if hasattr(self, "on_value"):
-            for name, (value, dir) in fragment.named_ports.items():
+            for name, (value, dir) in fragment.ports.items():
                 if isinstance(value, Value):
-                    new_fragment.named_ports[name] = self.on_value(value), dir
+                    new_fragment.ports[name] = self.on_value(value), dir
                 else:
-                    new_fragment.named_ports[name] = value, dir
+                    new_fragment.ports[name] = value, dir
         else:
-            new_fragment.named_ports = OrderedDict(fragment.named_ports.items())
+            new_fragment.ports = OrderedDict(fragment.ports.items())
 
     def map_domains(self, fragment, new_fragment):
         for domain in fragment.iter_domains():
@@ -302,7 +302,7 @@ class FragmentTransformer:
         elif isinstance(fragment, Instance):
             new_fragment = Instance(fragment.type, src_loc=fragment.src_loc)
             new_fragment.parameters = OrderedDict(fragment.parameters)
-            self.map_named_ports(fragment, new_fragment)
+            self.map_ports(fragment, new_fragment)
         elif isinstance(fragment, IOBufferInstance):
             if hasattr(self, "on_value"):
                 new_fragment = IOBufferInstance(
@@ -452,7 +452,7 @@ class DomainCollector(ValueVisitor, StatementVisitor):
                 self._add_used_domain(port._domain)
 
         if isinstance(fragment, Instance):
-            for name, (value, dir) in fragment.named_ports.items():
+            for name, (value, dir) in fragment.ports.items():
                 if not isinstance(value, IOValue):
                     self.on_value(value)
 

--- a/tests/test_hdl_ir.py
+++ b/tests/test_hdl_ir.py
@@ -721,7 +721,7 @@ class InstanceTestCase(FHDLTestCase):
             ("PARAM1", 0x1234),
             ("PARAM2", 0x5678),
         ]))
-        self.assertEqual(inst.named_ports, OrderedDict([
+        self.assertEqual(inst.ports, OrderedDict([
             ("s1", (s1, "i")),
             ("s2", (s2, "o")),
             ("io1", (io1, "i")),
@@ -741,10 +741,10 @@ class InstanceTestCase(FHDLTestCase):
             i_s3=3,
             io_s4=Cat(),
         )
-        self.assertRepr(inst.named_ports["s1"][0], "(const 1'd1)")
-        self.assertRepr(inst.named_ports["s2"][0], "(io-cat )")
-        self.assertRepr(inst.named_ports["s3"][0], "(const 2'd3)")
-        self.assertRepr(inst.named_ports["s4"][0], "(io-cat )")
+        self.assertRepr(inst.ports["s1"][0], "(const 1'd1)")
+        self.assertRepr(inst.ports["s2"][0], "(io-cat )")
+        self.assertRepr(inst.ports["s3"][0], "(const 2'd3)")
+        self.assertRepr(inst.ports["s4"][0], "(io-cat )")
 
     def test_wrong_construct_arg(self):
         s = Signal()
@@ -782,7 +782,7 @@ class InstanceTestCase(FHDLTestCase):
         f = self.inst
         self.assertEqual(f.type, "cpu")
         self.assertEqual(f.parameters, OrderedDict([("RESET", 0x1234)]))
-        self.assertEqual(list(f.named_ports.keys()), ["clk", "rst", "stb", "data", "pins"])
+        self.assertEqual(list(f.ports.keys()), ["clk", "rst", "stb", "data", "pins"])
 
     def test_prepare_attrs(self):
         self.setUp_cpu()


### PR DESCRIPTION
Made possible by the new port propagation code freeing up the name.