### PR TITLE
Deprecate `{Const,Signal}.{width,signed}` accessors

### DIFF
--- a/amaranth/hdl/_mem.py
+++ b/amaranth/hdl/_mem.py
@@ -44,7 +44,7 @@ class MemoryInstance(Fragment):
             assert len(self._en) == 1
             if domain == "comb":
                 assert isinstance(self._en, Const)
-                assert self._en.width == 1
+                assert self._en.shape() == unsigned(1)
                 assert self._en.value == 1
                 assert not self._transparent_for
 

--- a/amaranth/hdl/_xfrm.py
+++ b/amaranth/hdl/_xfrm.py
@@ -602,7 +602,7 @@ class _ControlInserter(FragmentTransformer):
 
 class ResetInserter(_ControlInserter):
     def _insert_control(self, fragment, domain, signals):
-        stmts = [s.eq(Const(s.init, s.width)) for s in signals if not s.reset_less]
+        stmts = [s.eq(Const(s.init, s.shape())) for s in signals if not s.reset_less]
         fragment.add_statements(domain, Switch(self.controls[domain], {1: stmts}, src_loc=self.src_loc))
 
 

--- a/tests/test_hdl_ast.py
+++ b/tests/test_hdl_ast.py
@@ -897,18 +897,16 @@ class SliceTestCase(FHDLTestCase):
     def test_const(self):
         a = Const.cast(Const(0x1234, 16)[4:12])
         self.assertEqual(a.value, 0x23)
-        self.assertEqual(a.width, 8)
-        self.assertEqual(a.signed, False)
+        self.assertEqual(a.shape(), unsigned(8))
         a = Const.cast(Const(-4, signed(8))[1:6])
         self.assertEqual(a.value, 0x1e)
-        self.assertEqual(a.width, 5)
-        self.assertEqual(a.signed, False)
+        self.assertEqual(a.shape(), unsigned(5))
 
 
 class BitSelectTestCase(FHDLTestCase):
     def setUp(self):
         self.c = Const(0, 8)
-        self.s = Signal(range(self.c.width))
+        self.s = Signal(range(len(self.c)))
 
     def test_shape(self):
         s1 = self.c.bit_select(self.s, 2)
@@ -946,7 +944,7 @@ class BitSelectTestCase(FHDLTestCase):
 class WordSelectTestCase(FHDLTestCase):
     def setUp(self):
         self.c = Const(0, 8)
-        self.s = Signal(range(self.c.width))
+        self.s = Signal(range(len(self.c)))
 
     def test_shape(self):
         s1 = self.c.word_select(self.s, 2)
@@ -1043,12 +1041,10 @@ class CatTestCase(FHDLTestCase):
     def test_const(self):
         a = Const.cast(Cat(Const(1, 1), Const(0, 1), Const(3, 2), Const(2, 2)))
         self.assertEqual(a.value, 0x2d)
-        self.assertEqual(a.width, 6)
-        self.assertEqual(a.signed, False)
+        self.assertEqual(a.shape(), unsigned(6))
         a = Const.cast(Cat(Const(-4, 8), Const(-3, 8)))
         self.assertEqual(a.value, 0xfdfc)
-        self.assertEqual(a.width, 16)
-        self.assertEqual(a.signed, False)
+        self.assertEqual(a.shape(), unsigned(16))
 
 
 class ArrayTestCase(FHDLTestCase):


### PR DESCRIPTION
These accessors used to be necessary (in addition to `.shape()`) while the AST nodes were mutable. However, after commit 2bf1b4da that made AST nodes immutable, there is no technical requirement to keep them around. Additionally:

- `len(value)` is shorter than `value.width` and works with any `value`
- `value.shape().signed` is longer than `value.signed` but works with any `value`