### PR TITLE
hdl._ir: raise an error when an elaboratable is duplicated in hierarchy.

### DIFF
--- a/amaranth/hdl/_xfrm.py
+++ b/amaranth/hdl/_xfrm.py
@@ -319,6 +319,7 @@ class FragmentTransformer:
         else:
             new_fragment = Fragment(src_loc=fragment.src_loc)
         new_fragment.attrs = OrderedDict(fragment.attrs)
+        new_fragment.origins = fragment.origins
         self.map_subfragments(fragment, new_fragment)
         self.map_domains(fragment, new_fragment)
         self.map_statements(fragment, new_fragment)

--- a/tests/test_hdl_ir.py
+++ b/tests/test_hdl_ir.py
@@ -77,6 +77,18 @@ class FragmentDriversTestCase(FHDLTestCase):
         self.assertEqual(list(f.iter_sync()), [])
 
 
+class DuplicateElaboratableTestCase(FHDLTestCase):
+    def test_duplicate(self):
+        sub = Module()
+        m = Module()
+        m.submodules.a = sub
+        m.submodules.b = sub
+        with self.assertRaisesRegex(DuplicateElaboratable,
+                r"^Elaboratable .* is included twice in the hierarchy, as "
+                r"top\.a and top\.b$"):
+            Fragment.get(m, None).prepare()
+
+
 class FragmentPortsTestCase(FHDLTestCase):
     def setUp(self):
         self.s1 = Signal()


### PR DESCRIPTION
Fixes #1194.