### PR TITLE
lib.wiring: allow reset-less signals in interfaces

### DIFF
--- a/amaranth/lib/wiring.py
+++ b/amaranth/lib/wiring.py
@@ -893,10 +893,6 @@ class Signature(metaclass=SignatureMeta):
                                            f"the initial value {member.init!r}, but it has "
                                            f"the initial value {attr_value_cast.init!r}")
                         return False
-                    if attr_value_cast.reset_less:
-                        if reasons is not None:
-                            reasons.append(f"{_format_path(path)} is expected to not be reset-less")
-                        return False
                 return True
             if member.is_signature:
                 return member.signature.is_compliant(attr_value, reasons=reasons, path=path)

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -107,6 +107,7 @@ Standard library changes
 * Added: :mod:`amaranth.lib.memory`. (`RFC 45`_)
 * Added: :class:`amaranth.lib.data.Const` class. (`RFC 51`_)
 * Changed: :meth:`amaranth.lib.data.Layout.const` returns a :class:`amaranth.lib.data.Const`, not a view (`RFC 51`_)
+* Changed: :meth:`amaranth.lib.wiring.Signature.is_compliant` no longer rejects reset-less signals.
 * Added: :class:`amaranth.lib.io.SingleEndedPort`, :class:`amaranth.lib.io.DifferentialPort`. (`RFC 55`_)
 * Added: :class:`amaranth.lib.io.Buffer`, :class:`amaranth.lib.io.FFBuffer`, :class:`amaranth.lib.io.DDRBuffer`. (`RFC 55`_)
 * Removed: (deprecated in 0.4) :mod:`amaranth.lib.scheduler`. (`RFC 19`_)

--- a/tests/test_lib_wiring.py
+++ b/tests/test_lib_wiring.py
@@ -453,10 +453,10 @@ class SignatureTestCase(unittest.TestCase):
             r"^'obj\.a' is expected to have the initial value 1, but it has the initial value 0$",
             sig=Signature({"a": In(1, init=1)}),
             obj=NS(a=Signal(1)))
-        self.assertNotCompliant(
-            r"^'obj\.a' is expected to not be reset-less$",
-            sig=Signature({"a": In(1)}),
-            obj=NS(a=Signal(1, reset_less=True)))
+        self.assertTrue(
+            Signature({"a": In(1)}).is_compliant(
+                NS(signature=Signature({"a": In(1)}),
+                   a=Signal(1, reset_less=True))))
         self.assertNotCompliant(
             r"^'obj\.a' does not have an attribute 'b'$",
             sig=Signature({"a": Out(Signature({"b": In(1)}))}),


### PR DESCRIPTION
This check was originally added out of abundance of caution, but since then it was observed that reset-less-ness is purely an implementation detail (see #1220), and furthermore it interferes with adaptation of `FIFOInterface` signals (where `[rw]_data` are reset-less) for RFC 61.

Fixes #1220.