### PR TITLE
back.rtlil: implement remaining format specifiers.

### DIFF
--- a/amaranth/back/verilog.py
+++ b/amaranth/back/verilog.py
@@ -9,7 +9,7 @@ __all__ = ["YosysError", "convert", "convert_fragment"]
 
 def _convert_rtlil_text(rtlil_text, *, strip_internal_attrs=False, write_verilog_opts=()):
     # This version requirement needs to be synchronized with the one in pyproject.toml!
-    yosys = find_yosys(lambda ver: ver >= (0, 38))
+    yosys = find_yosys(lambda ver: ver >= (0, 39, 0, 165))
 
     script = []
     script.append(f"read_ilang <<rtlil\n{rtlil_text}\nrtlil")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 # - pyproject.toml: tool.pdm.dev-dependencies.test
 # - amaranth/back/verilog.py: _convert_rtlil_text
 # - docs/install.rst: yosys-version
-builtin-yosys = ["amaranth-yosys>=0.38"]
+builtin-yosys = ["amaranth-yosys>=0.39.0.165.post92"]
 remote-build  = ["paramiko~=2.7"]
 
 [project.scripts]
@@ -65,7 +65,7 @@ source-includes = [
 [tool.pdm.dev-dependencies]
 # This version requirement needs to be synchronized with the one in pyproject.toml above!
 test = [
-  "yowasp-yosys>=0.38",
+  "yowasp-yosys>=0.39.0.165.post92",
   "coverage",
 ]
 docs = [

--- a/tests/test_back_rtlil.py
+++ b/tests/test_back_rtlil.py
@@ -1889,6 +1889,127 @@ class PrintTestCase(RTLILTestCase):
         end
         """)
 
+    def test_print_char(self):
+        i = Signal(21)
+        m = Module()
+        m.d.comb += [
+            Print(Format("{:c} {:-<5c} {:->5c}", i, i, i)),
+        ]
+        self.assertRTLIL(m, [i], R"""
+        attribute \generator "Amaranth"
+        attribute \top 1
+        module \top
+            wire width 21 input 0 \i
+            wire width 1 $1
+            process $2
+                assign $1 [0] 1'0
+                assign $1 [0] 1'1
+            end
+            cell $print $3
+                parameter \FORMAT "{21:U} {21:U}---- ----{21:U}\n"
+                parameter \ARGS_WIDTH 63
+                parameter signed \PRIORITY 32'11111111111111111111111111111110
+                parameter \TRG_ENABLE 0
+                parameter \TRG_WIDTH 0
+                parameter \TRG_POLARITY 0
+                connect \EN $1 [0]
+                connect \ARGS { \i [20:0] \i [20:0] \i [20:0] }
+                connect \TRG { }
+            end
+        end
+        """)
+
+    def test_print_base(self):
+        i = Signal(8)
+        m = Module()
+        m.d.comb += [
+            Print(Format("{:b} {:o} {:d} {:x} {:X} {:#x} {:#d} {:#_x}", i, i, i, i, i, i, i, i)),
+        ]
+        self.assertRTLIL(m, [i], R"""
+        attribute \generator "Amaranth"
+        attribute \top 1
+        module \top
+            wire width 8 input 0 \i
+            wire width 1 $1
+            process $2
+                assign $1 [0] 1'0
+                assign $1 [0] 1'1
+            end
+            cell $print $3
+                parameter \FORMAT "{8:> bu} {8:> ou} {8:> du} {8:> hu} {8:> Hu} {8:> h#u} {8:> du} {8:> h#_u}\n"
+                parameter \ARGS_WIDTH 64
+                parameter signed \PRIORITY 32'11111111111111111111111111111110
+                parameter \TRG_ENABLE 0
+                parameter \TRG_WIDTH 0
+                parameter \TRG_POLARITY 0
+                connect \EN $1 [0]
+                connect \ARGS { \i [7:0] \i [7:0] \i [7:0] \i [7:0] \i [7:0] \i [7:0] \i [7:0] \i [7:0] }
+                connect \TRG { }
+            end
+        end
+        """)
+
+    def test_print_sign(self):
+        i = Signal(8)
+        m = Module()
+        m.d.comb += [
+            Print(Format("{:5x} {:-5x} {:+5x} {: 5x}", i, i, i, i)),
+        ]
+        self.assertRTLIL(m, [i], R"""
+        attribute \generator "Amaranth"
+        attribute \top 1
+        module \top
+            wire width 8 input 0 \i
+            wire width 1 $1
+            process $2
+                assign $1 [0] 1'0
+                assign $1 [0] 1'1
+            end
+            cell $print $3
+                parameter \FORMAT "{8:> 5hu} {8:> 5h-u} {8:> 5h+u} {8:> 5h u}\n"
+                parameter \ARGS_WIDTH 32
+                parameter signed \PRIORITY 32'11111111111111111111111111111110
+                parameter \TRG_ENABLE 0
+                parameter \TRG_WIDTH 0
+                parameter \TRG_POLARITY 0
+                connect \EN $1 [0]
+                connect \ARGS { \i [7:0] \i [7:0] \i [7:0] \i [7:0] }
+                connect \TRG { }
+            end
+        end
+        """)
+
+    def test_print_align(self):
+        i = Signal(8)
+        m = Module()
+        m.d.comb += [
+            Print(Format("{:<5x} {:>5x} {:=5x} {:05x} {:-<5x}", i, i, i, i, i)),
+        ]
+        self.assertRTLIL(m, [i], R"""
+        attribute \generator "Amaranth"
+        attribute \top 1
+        module \top
+            wire width 8 input 0 \i
+            wire width 1 $1
+            process $2
+                assign $1 [0] 1'0
+                assign $1 [0] 1'1
+            end
+            cell $print $3
+                parameter \FORMAT "{8:< 5hu} {8:> 5hu} {8:= 5hu} {8:=05hu} {8:<-5hu}\n"
+                parameter \ARGS_WIDTH 40
+                parameter signed \PRIORITY 32'11111111111111111111111111111110
+                parameter \TRG_ENABLE 0
+                parameter \TRG_WIDTH 0
+                parameter \TRG_POLARITY 0
+                connect \EN $1 [0]
+                connect \ARGS { \i [7:0] \i [7:0] \i [7:0] \i [7:0] \i [7:0] }
+                connect \TRG { }
+            end
+        end
+        """)
+
+
 class ComponentTestCase(RTLILTestCase):
     def test_component(self):
         class MyComponent(wiring.Component):
@@ -1907,4 +2028,3 @@ class ComponentTestCase(RTLILTestCase):
         connect \o 8'00000000
         end
         """)
-


### PR DESCRIPTION
This requires a Yosys version from git. The requirement should be bumped to a proper release before Amaranth 0.5.