### PR TITLE
Dark theme for documentation

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -23,3 +23,7 @@ a { text-decoration: underline; }
 
 /* Work around https://github.com/readthedocs/sphinx_rtd_theme/issues/1301 */
 .py.property { display: block !important; }
+
+/* WaveDrom diagram theming */
+:root[data-theme="light"] { img { color-scheme: light; } }
+:root[data-theme="dark"] { img { color-scheme: dark; } }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,6 +16,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
     "sphinx_rtd_theme",
+    "sphinx_rtd_dark_mode",
     "sphinxcontrib.platformpicker",
     "sphinxcontrib.yowasp_wavedrom",
 ]
@@ -45,8 +46,6 @@ napoleon_custom_sections = [
     ("Members", "params_style"), # `lib.wiring` signature members
     "Platform overrides"
 ]
-
-yowasp_wavedrom_skin = "light"
 
 html_theme = "sphinx_rtd_theme"
 html_static_path = ["_static"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,8 +71,9 @@ test = [
 docs = [
   "sphinx~=7.1",
   "sphinxcontrib-platformpicker~=1.3",
-  "sphinxcontrib-yowasp-wavedrom~=1.1",
+  "sphinxcontrib-yowasp-wavedrom~=1.3",
   "sphinx-rtd-theme~=2.0",
+  "sphinx-rtd-dark-mode~=1.3",
   "sphinx-autobuild",
 ]
 examples = [


### PR DESCRIPTION
See [preview](https://whitequark.github.io/amaranth/docs/dark-theme/stdlib/memory.html).

Unfortunately this approach (using [sphinx-rtd-dark-mode](https://pypi.org/project/sphinx-rtd-dark-mode/)) has several issues:
- [ ] Parts of the theme are outright broken and unreadable (see below; these are examples from the preview link)
- [ ] No detection of user preference via media query
- [ ] The top left corner looks weird; needs more contrast for the search box, and a lighter background
- [ ] The fading is incredibly annoying (try clicking the light/dark mode a few times in a row)

![Screenshot_20240407_093703](https://github.com/amaranth-lang/amaranth/assets/54771/00d577df-4795-4697-ba65-4825e2d1c001)
![Screenshot_20240407_093718](https://github.com/amaranth-lang/amaranth/assets/54771/f9d5278d-fcec-4ece-bbff-e4c68688d015)

I'm not planning on fixing this but I do welcome assistance.