### PR TITLE
Document RFC 62

### DIFF
--- a/amaranth/hdl/__init__.py
+++ b/amaranth/hdl/__init__.py
@@ -8,7 +8,7 @@ from ._dsl import Module
 from ._cd import DomainError, ClockDomain
 from ._ir import UnusedElaboratable, Elaboratable, DriverConflict, Fragment
 from ._ir import Instance, IOBufferInstance
-from ._mem import MemoryData, MemoryInstance, Memory, ReadPort, WritePort, DummyPort
+from ._mem import FrozenMemory, MemoryData, MemoryInstance, Memory, ReadPort, WritePort, DummyPort
 from ._rec import Record
 from ._xfrm import DomainRenamer, ResetInserter, EnableInserter
 
@@ -29,7 +29,7 @@ __all__ = [
     "UnusedElaboratable", "Elaboratable", "DriverConflict", "Fragment",
     "Instance", "IOBufferInstance",
     # _mem
-    "MemoryData", "MemoryInstance", "Memory", "ReadPort", "WritePort", "DummyPort",
+    "FrozenMemory", "MemoryData", "MemoryInstance", "Memory", "ReadPort", "WritePort", "DummyPort",
     # _rec
     "Record",
     # _xfrm

--- a/docs/stdlib/memory.rst
+++ b/docs/stdlib/memory.rst
@@ -170,17 +170,39 @@ However, the memory read port is also configured to be *transparent* relative to
     }
 
 
-Memories
-========
+Simulation
+==========
+
+.. todo::
+
+    This section will be written once the simulator itself is documented.
+
+
+Memory description
+==================
+
+.. autoexception:: amaranth.hdl.FrozenMemory
+
+.. autoclass:: amaranth.hdl.MemoryData
+
+
+Memory component
+================
 
 ..
     attributes are not documented because they can be easily used to break soundness and we don't
     document them for signals either; they are rarely necessary for interoperability
 
-.. autoclass:: Memory(*, depth, shape, init, src_loc_at=0)
-    :no-members:
+..
+    the following two directives document a pair of overloads of :class:`Memory`; this is a little
+    weird and not really how rst/sphinx are supposed to work but it results in a comprehensible
+    generated document. be careful to not break this!
 
-    .. autoclass:: amaranth.lib.memory::Memory.Init(...)
+.. class:: Memory(data, *, src_loc_at=0)
+
+.. autoclass:: Memory(*, shape, depth, init, src_loc_at=0)
+    :noindex:
+    :no-members:
 
     .. automethod:: read_port
 

--- a/tests/test_lib_memory.py
+++ b/tests/test_lib_memory.py
@@ -439,15 +439,15 @@ class MemoryTestCase(FHDLTestCase):
         m = memory.Memory(shape=unsigned(8), depth=4, init=[])
         m.write_port()
         m.elaborate(None)
-        with self.assertRaisesRegex(memory.FrozenError,
+        with self.assertRaisesRegex(memory.FrozenMemory,
                 r"^Cannot add a memory port to a memory that has already been elaborated$"):
             m.write_port()
-        with self.assertRaisesRegex(memory.FrozenError,
+        with self.assertRaisesRegex(memory.FrozenMemory,
                 r"^Cannot add a memory port to a memory that has already been elaborated$"):
             m.read_port()
-        with self.assertRaisesRegex(memory.FrozenError,
+        with self.assertRaisesRegex(memory.FrozenMemory,
                 r"^Cannot set 'init' on a memory that has already been elaborated$"):
             m.init = [1, 2, 3, 4]
-        with self.assertRaisesRegex(memory.FrozenError,
+        with self.assertRaisesRegex(memory.FrozenMemory,
                 r"^Cannot set 'init' on a memory that has already been elaborated$"):
             m.init[0] = 1


### PR DESCRIPTION
This includes a few minor code changes:
- Removing redundant `lib.memory.Memory.Init = hdl.MemoryData.Init` re-export;
- Renaming `FrozenError` to `FrozenMemory` and moving it to `.hdl`;
- Marking `ReadPort` and `WritePort` as `@final`.