### PR TITLE
vendor: LatticeICE40Platform→SiliconBluePlatform.

### DIFF
--- a/amaranth/vendor/__init__.py
+++ b/amaranth/vendor/__init__.py
@@ -12,6 +12,7 @@ __all__ = [
     "LatticeMachXO2Platform",
     "LatticeMachXO3LPlatform",
     "QuicklogicPlatform",
+    "SiliconBluePlatform",
     "XilinxPlatform",
 ]
 
@@ -30,15 +31,15 @@ def __getattr__(name):
     if name == "LatticeECP5Platform":
         from ._lattice_ecp5 import LatticeECP5Platform
         return LatticeECP5Platform
-    if name == "LatticeICE40Platform":
-        from ._lattice_ice40 import LatticeICE40Platform
-        return LatticeICE40Platform
     if name in ("LatticeMachXO2Platform", "LatticeMachXO3LPlatform"):
         from ._lattice_machxo_2_3l import LatticeMachXO2Or3LPlatform
         return LatticeMachXO2Or3LPlatform
     if name == "QuicklogicPlatform":
         from ._quicklogic import QuicklogicPlatform
         return QuicklogicPlatform
+    if name in ("SiliconBluePlatform", "LatticeICE40Platform"):
+        from ._siliconblue import SiliconBluePlatform
+        return SiliconBluePlatform
     if name == "XilinxPlatform":
         from ._xilinx import XilinxPlatform
         return XilinxPlatform

--- a/amaranth/vendor/_siliconblue.py
+++ b/amaranth/vendor/_siliconblue.py
@@ -1,3 +1,6 @@
+# Currently owned by Lattice, originally designed and built by a startup called SiliconBlue, which
+# was acquired by Lattice. The primitives are prefixed with `SB_` for that reason.
+
 from abc import abstractmethod
 
 from ..hdl import *
@@ -6,7 +9,7 @@ from ..lib import io
 from ..build import *
 
 
-class LatticeICE40Platform(TemplatedPlatform):
+class SiliconBluePlatform(TemplatedPlatform):
     """
     .. rubric:: IceStorm toolchain
 


### PR DESCRIPTION
Devices originally designed by SiliconBlue have one set of primitives, and devices originally designed by AT&T, Alcatel-Lucent, or Lattice have a different set of primitives. This is the first step in merging the non-SiliconBlue Lattice platforms into one.