### PR TITLE
pyproject: use `.dev{distance}`, not `+{node}`, for non-release builds

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -132,6 +132,8 @@ jobs:
     steps:
       - name: Check out source code
         uses: actions/checkout@v4
+        with:
+            fetch-depth: 0
       - name: Set up PDM
         uses: pdm-project/setup-pdm@v4
         with:

--- a/pdm_build.py
+++ b/pdm_build.py
@@ -1,11 +1,24 @@
+import os
+from datetime import datetime
+from pdm.backend.hooks.version import SCMVersion
 from pdm.backend._vendor.packaging.version import Version
 
 
-# This is done in a PDM build hook without specifying `dynamic = [..., "version"]` to put all
-# of the static metadata into pyproject.toml. Tools other than PDM will not execute this script
-# and will use the generic version of the documentation URL (which redirects to /latest).
+def format_version(version: SCMVersion) -> str:
+    major, minor, patch = (int(n) for n in str(version.version).split(".")[:3])
+    dirty = f"+{datetime.utcnow():%Y%m%d.%H%M%S}" if version.dirty else ""
+    if version.distance is None:
+        return f"{major}.{minor}.{patch}{dirty}"
+    else:
+        return f"{major}.{minor}.{patch}.dev{version.distance}{dirty}"
+
+
 def pdm_build_initialize(context):
     version = Version(context.config.metadata["version"])
+
+    # This is done in a PDM build hook without specifying `dynamic = [..., "version"]` to put all
+    # of the static metadata into pyproject.toml. Tools other than PDM will not execute this script
+    # and will use the generic version of the documentation URL (which redirects to /latest).
     if version.is_prerelease:
         url_version = "latest"
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 
 [tool.pdm.version]
 source = "scm"
+version_format = "pdm_build:format_version"
 
 [project]
 dynamic = ["version"]
@@ -39,7 +40,7 @@ amaranth-rpc = "amaranth.rpc:main"
 # Build system configuration
 
 [build-system]
-requires = ["pdm-backend"]
+requires = ["pdm-backend @ git+https://github.com/pdm-project/pdm-backend@885bc8d9b75d068a34b2df86c6324c5fdf5c0cc8"]
 build-backend = "pdm.backend"
 
 [tool.pdm]


### PR DESCRIPTION
At the moment this uses a git URL for pdm-backend because required PDM functionality (pdm-project/pdm-backend#217) is not released yet.

Fixes #1229 (hopefully).