### PR TITLE
vendor._lattice: Add clock constraints to oxide .pdc template.

### DIFF
--- a/amaranth/vendor/_lattice.py
+++ b/amaranth/vendor/_lattice.py
@@ -527,6 +527,13 @@ class LatticePlatform(TemplatedPlatform):
                 ldc_set_port -iobuf {{ '{' }}{%- for key, value in attrs.items() %}{{key}}={{value}} {% endfor %}{{ '}' }} {{'['}}get_ports {{port_name}}{{']'}}
                 {% endif %}
             {% endfor %}
+            {% for net_signal, port_signal, frequency in platform.iter_clock_constraints() -%}
+                {% if port_signal is not none -%}
+                    create_clock -name {{port_signal.name|tcl_quote}} -period {{1000000000/frequency}} [get_ports {{port_signal.name|tcl_quote}}]
+                {% else -%}
+                    create_clock -name {{net_signal.name|tcl_quote}} -period {{1000000000/frequency}} [get_nets {{net_signal|hierarchy("/")|tcl_quote}}]
+                {% endif %}
+            {% endfor %}
             {{get_override("add_preferences")|default("# (add_preferences placeholder)")}}
         """
     }


### PR DESCRIPTION
Use `create_clock` to set clock constraints in .pdc file generated for oxide as per: https://github.com/amaranth-lang/amaranth/pull/759#discussion_r1561582932. 
