### PR TITLE
Forbid empty string as submodule name

### DIFF
--- a/amaranth/hdl/_dsl.py
+++ b/amaranth/hdl/_dsl.py
@@ -654,6 +654,8 @@ class Module(_ModuleBuilderRoot, Elaboratable):
         if name == None:
             self._anon_submodules.append((submodule, src_loc))
         else:
+            if name == "":
+                raise NameError("Submodule name must not be empty")
             if name in self._named_submodules:
                 raise NameError(f"Submodule named '{name}' already exists")
             self._named_submodules[name] = (submodule, src_loc)

--- a/tests/test_hdl_dsl.py
+++ b/tests/test_hdl_dsl.py
@@ -887,6 +887,12 @@ class DSLTestCase(FHDLTestCase):
         with self.assertRaisesRegex(NameError, r"^Submodule named 'foo' already exists$"):
             m1.submodules.foo = m2
 
+    def test_submodule_named_empty(self):
+        m1 = Module()
+        m2 = Module()
+        with self.assertRaisesRegex(NameError, r"^Submodule name must not be empty$"):
+            m1.submodules[""] = m2
+
     def test_submodule_get(self):
         m1 = Module()
         m2 = Module()


### PR DESCRIPTION
This is semantically ambiguous and breaks the RTLIL emitter.

Fixes #1209.