### PR TITLE
Add a diagnostic for slicing `data.View`

### DIFF
--- a/amaranth/lib/data.py
+++ b/amaranth/lib/data.py
@@ -792,6 +792,9 @@ class View(ValueCastable):
         :exc:`TypeError`
             If :meth:`.ShapeCastable.__call__` does not return a value or a value-castable object.
         """
+        if isinstance(key, slice):
+            raise TypeError(
+                "View cannot be indexed with a slice; did you mean to call `.as_value()` first?")
         if isinstance(self.__layout, ArrayLayout):
             if not isinstance(key, (int, Value, ValueCastable)):
                 raise TypeError(

--- a/tests/test_lib_data.py
+++ b/tests/test_lib_data.py
@@ -670,6 +670,12 @@ class ViewTestCase(FHDLTestCase):
                 r"with a value$"):
             Signal(data.StructLayout({}))[Signal(1)]
 
+    def test_index_wrong_slice(self):
+        with self.assertRaisesRegex(TypeError,
+                r"^View cannot be indexed with a slice; did you mean to call `.as_value\(\)` "
+                r"first\?$"):
+            Signal(data.StructLayout({}))[0:1]
+
     def test_getattr(self):
         v = Signal(data.UnionLayout({
             "a": unsigned(2),


### PR DESCRIPTION
This is meaningless for a view but meaningful for the underlying value.

Fixes #1375.