### PR TITLE
CI: never upload packages or add releases for `.dev` versions.

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -186,7 +186,7 @@ jobs:
           folder: docs/
           target-folder: docs/amaranth/latest/
       - name: Publish release documentation
-        if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v') }}
+        if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v') && !contains(github.event.ref, 'dev') }}
         uses: JamesIves/github-pages-deploy-action@releases/v4
         with:
           repository-name: amaranth-lang/amaranth-lang.github.io
@@ -272,12 +272,12 @@ jobs:
       with:
         repository-url: https://test.pypi.org/legacy/
     - name: Publish package to PyPI
-      if: ${{ github.repository == 'amaranth-lang/amaranth' && github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/') }}
+      if: ${{ github.repository == 'amaranth-lang/amaranth' && github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v') && !contains(github.event.ref, 'dev') }}
       uses: pypa/gh-action-pypi-publish@release/v1
 
   publish-release:
     needs: publish-package
-    if: ${{ github.repository == 'amaranth-lang/amaranth' && github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/') }}
+    if: ${{ github.repository == 'amaranth-lang/amaranth' && github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v') && !contains(github.event.ref, 'dev') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
This has resulted in the 0.5.0 tarball being unintentionally also released as 0.6.0 :(

(The reason we need tags like `0.6.0.dev0` in first place is for SCM version determination to work properly on the `main` branch.)