### PR TITLE
lib.data: make `len()` work on views of array layout.

### DIFF
--- a/amaranth/lib/data.py
+++ b/amaranth/lib/data.py
@@ -850,6 +850,12 @@ class View(ValueCastable):
                 f"may only be accessed by indexing")
         return item
 
+    def __len__(self):
+        if not isinstance(self.__layout, ArrayLayout):
+            raise TypeError(
+                f"`len()` can only be used on views of array layout, not {self.__layout!r}")
+        return self.__layout.length
+
     def __eq__(self, other):
         if isinstance(other, View) and self.__layout == other.__layout:
             return self.__target == other.__target

--- a/tests/test_lib_data.py
+++ b/tests/test_lib_data.py
@@ -763,6 +763,14 @@ class ViewTestCase(FHDLTestCase):
                 r"with the same layout, not .*$"):
             s1 != Const(0, 2)
 
+    def test_len(self):
+        s1 = Signal(data.StructLayout({"a": unsigned(2)}))
+        with self.assertRaisesRegex(TypeError,
+                r"^`len\(\)` can only be used on views of array layout, not StructLayout.*$"):
+            len(s1)
+        s2 = Signal(data.ArrayLayout(2, 3))
+        self.assertEqual(len(s2), 3)
+
     def test_operator(self):
         s1 = Signal(data.StructLayout({"a": unsigned(2)}))
         s2 = Signal(unsigned(2))


### PR DESCRIPTION
Fixes #1403.