### PR TITLE
Fix `repr()` of empty `SingleEndedPort`

### DIFF
--- a/amaranth/lib/io.py
+++ b/amaranth/lib/io.py
@@ -203,10 +203,10 @@ class SingleEndedPort(PortLike):
                                direction=self._direction & other._direction)
 
     def __repr__(self):
-        if all(self._invert):
-            invert = True
-        elif not any(self._invert):
+        if not any(self._invert):
             invert = False
+        elif all(self._invert):
+            invert = True
         else:
             invert = self._invert
         return f"SingleEndedPort({self._io!r}, invert={invert!r}, direction={self._direction})"

--- a/tests/test_lib_io.py
+++ b/tests/test_lib_io.py
@@ -88,6 +88,12 @@ class SingleEndedPortTestCase(FHDLTestCase):
         iport = ~port
         self.assertRepr(iport, "SingleEndedPort((io-port io), invert=(False, True, False, True), direction=Direction.Output)")
 
+    def test_empty(self):
+        io = IOPort(1)
+        port = SingleEndedPort(io, invert=False)
+        eport = port[0:0]
+        self.assertRepr(eport, "SingleEndedPort((io-slice (io-port io) 0:0), invert=False, direction=Direction.Bidir)")
+
 
 class DifferentialPortTestCase(FHDLTestCase):
     def test_construct(self):
@@ -159,6 +165,13 @@ class DifferentialPortTestCase(FHDLTestCase):
         port = DifferentialPort(iop, ion, invert=[True, False, True, False], direction=Direction.Output)
         iport = ~port
         self.assertRepr(iport, "DifferentialPort((io-port iop), (io-port ion), invert=(False, True, False, True), direction=Direction.Output)")
+
+    def test_empty(self):
+        iop = IOPort(1)
+        ion = IOPort(1)
+        port = DifferentialPort(iop, ion, invert=False)
+        eport = port[0:0]
+        self.assertRepr(eport, "DifferentialPort((io-slice (io-port iop) 0:0), (io-slice (io-port ion) 0:0), invert=False, direction=Direction.Bidir)")
 
 
 class BufferTestCase(FHDLTestCase):


### PR DESCRIPTION
Before this PR, any such port would be displayed as `invert=True`, which is confusing if the original port had no inversion.

`DifferentialPort` is unaffected.