### PR TITLE
lib.wiring: check type of `m` in `connect(m, ...)` [0.5 backport]

### DIFF
--- a/amaranth/lib/wiring.py
+++ b/amaranth/lib/wiring.py
@@ -5,6 +5,7 @@ import warnings
 
 from .. import tracer
 from ..hdl._ast import Shape, ShapeCastable, Const, Signal, Value, ValueCastable
+from ..hdl._dsl import Module
 from ..hdl._ir import Elaboratable
 from .._utils import final
 from .meta import Annotation, InvalidAnnotation
@@ -1400,6 +1401,9 @@ def connect(m, *args, **kwargs):
     arguments serve only a documentation purpose: they clarify the diagnostic messages when
     a connection cannot be made.
     """
+
+    if not isinstance(m, Module):
+        raise TypeError(f"The initial argument must be a module, not {m!r}")
 
     objects = {
         **{index:   arg for index,   arg in enumerate(args)},

--- a/tests/test_lib_wiring.py
+++ b/tests/test_lib_wiring.py
@@ -1045,6 +1045,15 @@ class ConnectTestCase(unittest.TestCase):
                      a=Signal(),
                      b=Signal()))
 
+    def test_bug_1435_missing_module(self):
+        sig = Signature({"a": Out(1)})
+        p = sig.create()
+        q = sig.flip().create()
+
+        with self.assertRaisesRegex(TypeError,
+                r"^The initial argument must be a module, not <PureInterface: .+>$"):
+            connect(p, q)
+
 
 class ComponentTestCase(unittest.TestCase):
     def test_basic(self):


### PR DESCRIPTION
See https://github.com/amaranth-lang/amaranth/pull/1436.