### PR TITLE
Add `payload_init=` argument to `lib.stream.Signature()` [0.5 backport]

### DIFF
--- a/amaranth/lib/stream.py
+++ b/amaranth/lib/stream.py
@@ -19,7 +19,9 @@ class Signature(wiring.Signature):
     Parameters
     ----------
     payload_shape : :class:`~.hdl.ShapeLike`
-        Shape of the payload.
+        Shape of the payload member.
+    payload_init : :ref:`constant-castable <lang-constcasting>` object
+        Initial value of the payload member.
     always_valid : :class:`bool`
         Whether the stream has a payload available each cycle.
     always_ready : :class:`bool`
@@ -35,14 +37,15 @@ class Signature(wiring.Signature):
     ready : :py:`In(1)`
         Whether a payload is accepted. If the stream is :py:`always_ready`, :py:`Const(1)`.
     """
-    def __init__(self, payload_shape: ShapeLike, *, always_valid=False, always_ready=False):
+    def __init__(self, payload_shape: ShapeLike, *, payload_init=None,
+                 always_valid=False, always_ready=False):
         Shape.cast(payload_shape)
         self._payload_shape = payload_shape
         self._always_valid = bool(always_valid)
         self._always_ready = bool(always_ready)
 
         super().__init__({
-            "payload": Out(payload_shape),
+            "payload": Out(payload_shape, init=payload_init),
             "valid": Out(1),
             "ready": In(1)
         })

--- a/tests/test_lib_stream.py
+++ b/tests/test_lib_stream.py
@@ -108,6 +108,11 @@ class StreamTestCase(FHDLTestCase):
         self.assertNotEqual(sig_av_ar,   sig_nav_nar)
         self.assertNotEqual(sig_av_ar,   sig_av_ar2)
 
+    def test_payload_init(self):
+        sig = stream.Signature(2, payload_init=0b10)
+        intf = sig.create()
+        self.assertEqual(intf.payload.init, 0b10)
+
     def test_interface_create_bad(self):
         with self.assertRaisesRegex(TypeError,
                 r"^Signature of stream\.Interface must be a stream\.Signature, not "


### PR DESCRIPTION
See https://github.com/amaranth-lang/amaranth/pull/1434.