### PR TITLE
build, vendor: use `dir="-"` in `create_missing_domain`.

### DIFF
--- a/amaranth/vendor/_gowin.py
+++ b/amaranth/vendor/_gowin.py
@@ -532,10 +532,14 @@ class GowinPlatform(TemplatedPlatform):
                                              o_OSCOUT=clk_i)
 
             else:
-                clk_i = self.request(self.default_clk).i
+                clk_io = self.request(self.default_clk, dir="-")
+                m.submodules.clk_buf = clk_buf = io.Buffer("i", clk_io)
+                clk_i = clk_buf.i
 
             if self.default_rst is not None:
-                rst_i = self.request(self.default_rst).i
+                rst_io = self.request(self.default_rst, dir="-")
+                m.submodules.rst_buf = rst_buf = io.Buffer("i", rst_io)
+                rst_i = rst_buf.i
             else:
                 rst_i = Const(0)
 

--- a/amaranth/vendor/_lattice.py
+++ b/amaranth/vendor/_lattice.py
@@ -956,9 +956,14 @@ class LatticePlatform(TemplatedPlatform):
                     o_HFCLKOUT=clk_i,
                 )
             else:
-                clk_i = self.request(self.default_clk).i
+                clk_io = self.request(self.default_clk, dir="-")
+                m.submodules.clk_buf = clk_buf = io.Buffer("i", clk_io)
+                clk_i = clk_buf.i
+
             if self.default_rst is not None:
-                rst_i = self.request(self.default_rst).i
+                rst_io = self.request(self.default_rst, dir="-")
+                m.submodules.rst_buf = rst_buf = io.Buffer("i", rst_io)
+                rst_i = rst_buf.i
             else:
                 rst_i = Const(0)
 

--- a/amaranth/vendor/_quicklogic.py
+++ b/amaranth/vendor/_quicklogic.py
@@ -1,6 +1,7 @@
 from abc import abstractmethod
 
 from ..hdl import *
+from ..lib import io
 from ..lib.cdc import ResetSynchronizer
 from ..build import *
 
@@ -172,10 +173,14 @@ class QuicklogicPlatform(TemplatedPlatform):
                                          o_A=sys_clk0,
                                          o_Z=clk_i)
             else:
-                clk_i = self.request(self.default_clk).i
+                clk_io = self.request(self.default_clk, dir="-")
+                m.submodules.clk_buf = clk_buf = io.Buffer("i", clk_io)
+                clk_i = clk_buf.i
 
             if self.default_rst is not None:
-                rst_i = self.request(self.default_rst).i
+                rst_io = self.request(self.default_rst, dir="-")
+                m.submodules.rst_buf = rst_buf = io.Buffer("i", rst_io)
+                rst_i = rst_buf.i
             else:
                 rst_i = Const(0)
 

--- a/amaranth/vendor/_siliconblue.py
+++ b/amaranth/vendor/_siliconblue.py
@@ -393,11 +393,15 @@ class SiliconBluePlatform(TemplatedPlatform):
                 delay = int(100e-6 * self.default_clk_frequency)
             # User-defined clock signal.
             else:
-                clk_i = self.request(self.default_clk).i
+                clk_io = self.request(self.default_clk, dir="-")
+                m.submodules.clk_buf = clk_buf = io.Buffer("i", clk_io)
+                clk_i = clk_buf.i
                 delay = int(15e-6 * self.default_clk_frequency)
 
             if self.default_rst is not None:
-                rst_i = self.request(self.default_rst).i
+                rst_io = self.request(self.default_rst, dir="-")
+                m.submodules.rst_buf = rst_buf = io.Buffer("i", rst_io)
+                rst_i = rst_buf.i
             else:
                 rst_i = Const(0)
 

--- a/amaranth/vendor/_xilinx.py
+++ b/amaranth/vendor/_xilinx.py
@@ -1144,11 +1144,16 @@ class XilinxPlatform(TemplatedPlatform):
             return super().create_missing_domain(name)
 
         if name == "sync" and self.default_clk is not None:
-            clk_i = self.request(self.default_clk).i
-            if self.default_rst is not None:
-                rst_i = self.request(self.default_rst).i
-
             m = Module()
+
+            clk_io = self.request(self.default_clk, dir="-")
+            m.submodules.clk_buf = clk_buf = io.Buffer("i", clk_io)
+            clk_i = clk_buf.i
+            if self.default_rst is not None:
+                rst_io = self.request(self.default_rst, dir="-")
+                m.submodules.rst_buf = rst_buf = io.Buffer("i", rst_io)
+                rst_i = rst_buf.i
+
             ready = Signal()
             m.submodules += Instance(STARTUP_PRIMITIVE[self.family], o_EOS=ready)
             m.domains += ClockDomain("sync", reset_less=self.default_rst is None)


### PR DESCRIPTION
Fixes #1402.