### PR TITLE
hdl: truncate init value read from `Signal(...).init`

### DIFF
--- a/amaranth/hdl/_ast.py
+++ b/amaranth/hdl/_ast.py
@@ -2052,7 +2052,7 @@ class Signal(Value, DUID, metaclass=_SignalMeta):
                             .format(orig_init, shape),
                     category=SyntaxWarning,
                     stacklevel=2)
-        self._init = init.value
+        self._init = Const(init.value, shape).value
         self._reset_less = bool(reset_less)
 
         if isinstance(orig_shape, range) and orig_init is not None and orig_init not in orig_shape:

--- a/tests/test_hdl_ast.py
+++ b/tests/test_hdl_ast.py
@@ -1245,6 +1245,14 @@ class SignalTestCase(FHDLTestCase):
                 r"^Initial value -2 will be truncated to the signal shape signed\(1\)$"):
             Signal(signed(1), init=-2)
 
+    def test_init_truncated(self):
+        s1 = Signal(unsigned(2), init=-1)
+        self.assertEqual(s1.init, 0b11)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(action="ignore", category=SyntaxWarning)
+            s2 = Signal(signed(2), init=-33)
+            self.assertEqual(s2.init, -1)
+
     def test_init_wrong_fencepost(self):
         with self.assertRaisesRegex(SyntaxError,
                 r"^Initial value 10 equals the non-inclusive end of the signal shape "


### PR DESCRIPTION
We have a warning saying that the init value will be truncated to fit the signal's shape (suppressed for common patterns of 0 and -1), but the introspected via `.init` value is, confusingly, not truncated.