### PR TITLE
hdl: truncate init value read from `Signal(...).init` [0.5 backport]

### DIFF
--- a/amaranth/hdl/_ast.py
+++ b/amaranth/hdl/_ast.py
@@ -2082,7 +2082,7 @@ class Signal(Value, DUID, metaclass=_SignalMeta):
                             .format(orig_init, shape),
                     category=SyntaxWarning,
                     stacklevel=2)
-        self._init = init.value
+        self._init = Const(init.value, shape).value
         self._reset_less = bool(reset_less)
 
         if isinstance(orig_shape, range) and orig_init is not None and orig_init not in orig_shape:

--- a/tests/test_hdl_ast.py
+++ b/tests/test_hdl_ast.py
@@ -1264,6 +1264,14 @@ class SignalTestCase(FHDLTestCase):
                 r"^Initial value -2 will be truncated to the signal shape signed\(1\)$"):
             Signal(signed(1), init=-2)
 
+    def test_init_truncated(self):
+        s1 = Signal(unsigned(2), init=-1)
+        self.assertEqual(s1.init, 0b11)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(action="ignore", category=SyntaxWarning)
+            s2 = Signal(signed(2), init=-33)
+            self.assertEqual(s2.init, -1)
+
     def test_init_wrong_fencepost(self):
         with self.assertRaisesRegex(SyntaxError,
                 r"^Initial value 10 equals the non-inclusive end of the signal shape "


### PR DESCRIPTION
See https://github.com/amaranth-lang/amaranth/pull/1449.