### PR TITLE
vendor._gowin: Fix sdc file syntax.

### DIFF
--- a/amaranth/vendor/_gowin.py
+++ b/amaranth/vendor/_gowin.py
@@ -443,9 +443,10 @@ class GowinPlatform(TemplatedPlatform):
             create_clock -name {{signal.name|tcl_quote}} -period {{1000000000/frequency}} [get_nets {{signal|hierarchy("/")|tcl_quote}}]
         {% endfor %}
         {% for port, frequency in platform.iter_port_clock_constraints() -%}
-            create_clock -name {{port.name|tcl_quote}} -period {{1000000000/frequency}} [get_ports {{port.name|tcl_quote}}]
+            create_clock -name {{port.name|tcl_quote}} -period {{1000000000/frequency}} [get_ports
+            {{ "{" }}{{port.name}}{{ "}" }}]
         {% endfor %}
-        {{get_override("add_constraints")|default("# (add_constraints placeholder)")}}
+        {{get_override("add_constraints")|default("// (add_constraints placeholder)")}}
         """,
     }
     _gowin_command_templates = [


### PR DESCRIPTION
SDC files for Gowin vendor toolchain are normally generated from the IDE.
Example syntax for 'create_clock' can be seen chapter 4.6 of SUG940-1.2E ("SUG940-1.2E_Gowin Design Timing Constraints User Guide.pdf").