### PR TITLE
docs/stdlib/data: improved wording describing example that is shape-like

### DIFF
--- a/docs/stdlib/data.rst
+++ b/docs/stdlib/data.rst
@@ -155,7 +155,7 @@ In case the data has related operations or transformations, :class:`View` can be
         def brightness(self):
             return (self.red + self.green + self.blue)[-8:]
 
-Here, the :py:`RGBLayout` class itself is :ref:`shape-like <lang-shapelike>` and can be used anywhere a shape is accepted. When a :class:`Signal` is constructed with this layout, the returned value is wrapped in an :py:`RGBView`:
+Here, an instance of the :py:`RGBLayout` class itself is :ref:`shape-like <lang-shapelike>` and can be used anywhere a shape is accepted. When a :class:`Signal` is constructed with this layout, the returned value is wrapped in an :py:`RGBView`:
 
 .. doctest::
 


### PR DESCRIPTION
The RGBLayout class itself is not shapelike, only instances of this class are shape-like. (i.e. `Shape.cast(RGBLayout)` would fail) It's worth being precise especially because in some cases the classes themselves are shape-like, for example in the case of Enums, the classes that inherit from Enum are shape-like.