### PR TITLE
docs/stdlib/fifo: document fifo stream interfaces

### DIFF
--- a/amaranth/lib/fifo.py
+++ b/amaranth/lib/fifo.py
@@ -60,6 +60,10 @@ class FIFOInterface:
         Does nothing if ``r_rdy`` is not asserted.
     r_level : Signal(range(depth + 1)), out
         Number of unread entries.
+    w_stream : :class:`amaranth.lib.wiring.FlippedInterface`
+        Returns a flipped :class:`amaranth.lib.stream.Interface`, which is constructed by renaming the usual FIFO write signals.
+    r_stream : :class:`amaranth.lib.stream.Interface`
+        Returns a stream interface, which is constructed by renaming the usual FIFO read signals.
     {r_attributes}
     """
 


### PR DESCRIPTION
Rendered document:
![image](https://github.com/user-attachments/assets/f6544209-6c20-441d-bf7e-7e865cbdc2b2)
