### PR TITLE
change gowin platform to use nextpnr-himbaechel

### DIFF
--- a/amaranth/vendor/_gowin.py
+++ b/amaranth/vendor/_gowin.py
@@ -169,7 +169,7 @@ class GowinPlatform(TemplatedPlatform):
 
     Required tools:
         * ``yosys``
-        * ``nextpnr-gowin``
+        * ``nextpnr-himbaechel`` with Gowin uarch
         * ``gowin_pack``
 
     The environment is populated by running the script specified in the environment variable
@@ -353,7 +353,7 @@ class GowinPlatform(TemplatedPlatform):
 
     _apicula_required_tools = [
         "yosys",
-        "nextpnr-gowin",
+        "nextpnr-himbaechel",
         "gowin_pack"
     ]
     _apicula_file_templates = {
@@ -393,14 +393,14 @@ class GowinPlatform(TemplatedPlatform):
             {{name}}.ys
         """,
         r"""
-        {{invoke_tool("nextpnr-gowin")}}
+        {{invoke_tool("nextpnr-himbaechel")}}
             {{quiet("--quiet")}}
             {{get_override("nextpnr_opts")|options}}
             --log {{name}}.tim
             --device {{platform.part}}
-            --family {{platform._chipdb_device}}
+            --vopt family={{platform._chipdb_device}}
             --json {{name}}.syn.json
-            --cst {{name}}.cst
+            --vopt cst={{name}}.cst
             --write {{name}}.pnr.json
         """,
         r"""

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -58,6 +58,14 @@ Standard library changes
 * Removed: (deprecated in 0.5.0) :mod:`amaranth.lib.coding`. (`RFC 63`_)
 
 
+Platform integration changes
+----------------------------
+
+.. currentmodule:: amaranth.vendor
+
+* Changed: the Gowin platform now uses ``nextpnr-himbaechel`` rather than ``nextpnr-gowin``.
+
+
 Version 0.5.1
 =============
 


### PR DESCRIPTION
Over at Apicula we're migrating from nextpnr-gowin to nextpnr-himbaechel, and this updates Amaranth to use the new target.

The old target was based on nextpnr-generic and had longstanding problems such as long load times and occasional miscompiles. The new target is implemented as a microarchitecture in nextpnr-himbaechel and is significantly faster, robuster, and already has more features than the old target. Only timing-driven synthesis is still in the works, after which the new target will be pretty much a superset of features.

This PR is slightly breaking in that the end user needs to install the new nextpnr target, but should otherwise be largely compatible. The only change is that if you're passing custom Apicula-specific arguments they need to be changed from `--option value` to `--vopt option=value`.

I have confirmed that this successfully builds a blinky on Tang Nano 9K with `python -m amaranth_boards.tang_nano_9k`