### PR TITLE
Bump sphinxcontrib-yowasp-wavedrom dependency

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -171,6 +171,14 @@ Specifying a shape with a range is convenient for counters, indexes, and all oth
    Python ranges are *exclusive* or *half-open*, meaning they do not contain their ``.stop`` element. Because of this, values with shapes cast from a ``range(stop)`` where ``stop`` is a power of 2 are not wide enough to represent ``stop`` itself:
 
    .. doctest::
+      :hide:
+
+      >>> import warnings
+      >>> _warning_filters_backup = warnings.catch_warnings()
+      >>> _warning_filters_backup.__enter__() # have to do this horrific hack to make it work with `PYTHONWARNINGS=error` :(
+      >>> warnings.simplefilter("default", amaranth.hdl._ast.SyntaxWarning)
+
+   .. doctest::
 
       >>> fencepost = C(256, range(256))
       <...>:1: SyntaxWarning: Value 256 equals the non-inclusive end of the constant shape range(0, 256); this is likely an off-by-one error
@@ -179,6 +187,11 @@ Specifying a shape with a range is convenient for counters, indexes, and all oth
       unsigned(8)
       >>> fencepost.value
       0
+
+   .. doctest::
+      :hide:
+
+      >>> _warning_filters_backup.__exit__()
 
    Amaranth detects uses of :class:`Const` and :class:`Signal` that invoke such an off-by-one error, and emits a diagnostic message.
 
@@ -671,6 +684,14 @@ Python expression Amaranth expression (boolean operands)
    When applied to Amaranth boolean values, the ``~`` operator computes negation, and when applied to Python boolean values, the ``not`` operator also computes negation. However, the ``~`` operator applied to Python boolean values produces an unexpected result:
 
    .. doctest::
+      :hide:
+
+      >>> import warnings
+      >>> _warning_filters_backup = warnings.catch_warnings()
+      >>> _warning_filters_backup.__enter__() # have to do this horrific hack to make it work with `PYTHONWARNINGS=error` :(
+      >>> warnings.simplefilter("ignore", DeprecationWarning)
+
+   .. doctest::
 
       >>> ~False
       -1
@@ -687,6 +708,11 @@ Python expression Amaranth expression (boolean operands)
       (| (const 1'd0) (sig stb))
       >>> ~use_stb | stb # WRONG! MSB of 2-bit wide OR expression is always 1
       (| (const 2'sd-2) (sig stb))
+
+   .. doctest::
+      :hide:
+
+      >>> _warning_filters_backup.__exit__()
 
    Amaranth automatically detects some cases of misuse of ``~`` and emits a detailed diagnostic message.
 

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1372,14 +1372,14 @@ A new synchronous :ref:`control domain <lang-domains>`, which is more often call
 
 .. testcode::
 
-    m.domains.video = cd_video = ClockDomain(local=True)
+    m.domains.video = cd_video = ClockDomain()
 
 If the name of the domain is not known upfront, another, less concise, syntax can be used instead:
 
 .. testcode::
 
     def add_video_domain(n):
-        cd = ClockDomain(f"video_{n}", local=True)
+        cd = ClockDomain(f"video_{n}")
         m.domains += cd
         return cd
 
@@ -1393,21 +1393,17 @@ A clock domain always has a clock signal, which can be accessed through the :att
 
 .. testcode::
 
-    m.domains.jtag = ClockDomain(clk_edge="neg", local=True)
+    m.domains.jtag = ClockDomain(clk_edge="neg")
 
 A clock domain also has a reset signal, which can be accessed through the :attr:`cd.rst <ClockDomain.rst>` attribute. The reset signal is always active-high: the signals in the clock domain are reset if the value of the reset signal is 1. The :ref:`initial value <lang-initial>` of this signal is 0, so if the reset signal is never assigned, the signals in the clock domain are never explicitly reset (they are still :ref:`reset at power-on <lang-initial>`). Nevertheless, if its existence is undesirable, the clock domain can be configured to omit it:
 
 .. testcode::
 
-    m.domains.startup = ClockDomain(reset_less=True, local=True)
+    m.domains.startup = ClockDomain(reset_less=True)
 
 Signals in a reset-less clock domain can still be explicitly reset using the :class:`ResetInserter` :ref:`control flow modifier <lang-controlinserter>`.
 
 If a clock domain is defined in a module, all of its :ref:`submodules <lang-submodules>` can refer to that domain under the same name.
-
-.. warning::
-
-    Always provide the :py:`local=True` keyword argument when defining a clock domain. The behavior of clock domains defined without this keyword argument is subject to change in near future, and is intentionally left undocumented.
 
 .. warning::
 
@@ -1447,7 +1443,7 @@ In this example, once the design is processed, the clock signal of the clock dom
 
 .. testcode::
 
-    m.domains.sync = cd_sync = ClockDomain(local=True)
+    m.domains.sync = cd_sync = ClockDomain()
     m.d.comb += [
         cd_sync.clk.eq(bus_clk),
         cd_sync.rst.eq(~bus_rstn),

--- a/docs/stdlib/io.rst
+++ b/docs/stdlib/io.rst
@@ -106,7 +106,7 @@ In this example, a clock domain is created and driven from an external clock sou
         def elaborate(self, platform):
             m = Module()
 
-            m.domains.sync = cd_sync = ClockDomain(local=True)
+            m.domains.sync = cd_sync = ClockDomain()
 
             m.submodules.clk24 = clk24 = io.Buffer("i", platform.request("clk24", dir="-"))
             m.d.comb += cd_sync.clk.eq(clk24.i)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ test = [
 docs = [
   "sphinx~=7.1",
   "sphinxcontrib-platformpicker~=1.3",
-  "sphinxcontrib-yowasp-wavedrom==1.7", # exact version to avoid changes in rendering
+  "sphinxcontrib-yowasp-wavedrom==1.8", # exact version to avoid changes in rendering
   "sphinx-rtd-theme~=2.0",
   "sphinx-autobuild",
 ]


### PR DESCRIPTION
This is currently breaking builds because of an invalid escape sequence warning being elevated to error severity.