### PR TITLE
hdl.mem: mask initial value to shape.

### DIFF
--- a/amaranth/hdl/_mem.py
+++ b/amaranth/hdl/_mem.py
@@ -3,6 +3,7 @@ from collections.abc import MutableSequence
 
 from .. import tracer
 from ._ast import *
+from ._ast import _get_init_value
 from ._ir import Fragment, AlreadyElaborated
 from ..utils import ceil_log2
 from .._utils import final
@@ -105,10 +106,11 @@ class MemoryData:
                 for actual_index, actual_value in zip(indices, value):
                     self[actual_index] = actual_value
             else:
+                raw = _get_init_value(value, self._shape, "memory")
                 if isinstance(self._shape, ShapeCastable):
-                    self._raw[index] = Const.cast(Const(value, self._shape)).value
+                    self._raw[index] = raw
                 else:
-                    value = operator.index(value)
+                    value = raw
                     # self._raw[index] assigned by the following line
                 self._elems[index] = value
 

--- a/tests/test_hdl_mem.py
+++ b/tests/test_hdl_mem.py
@@ -31,3 +31,29 @@ class MemoryDataTestCase(FHDLTestCase):
         with self.assertRaisesRegex(ValueError,
                 r"^Value \(memory-row \(memory-data data\) 0\) can only be used in simulator processes$"):
             m.d.comb += data[0].eq(1)
+
+
+class InitTestCase(FHDLTestCase):
+    def test_ones(self):
+        init = MemoryData.Init([-1, 12], shape=8, depth=2)
+        self.assertEqual(list(init), [0xff, 12])
+        init = MemoryData.Init([-1, -12], shape=signed(8), depth=2)
+        self.assertEqual(list(init), [-1, -12])
+
+    def test_trunc(self):
+        with self.assertWarnsRegex(SyntaxWarning,
+                r"^Initial value -2 is signed, but the memory shape is unsigned\(8\)$"):
+            init = MemoryData.Init([-2, 12], shape=8, depth=2)
+        self.assertEqual(list(init), [0xfe, 12])
+        with self.assertWarnsRegex(SyntaxWarning,
+                r"^Initial value 258 will be truncated to the memory shape unsigned\(8\)$"):
+            init = MemoryData.Init([258, 129], shape=8, depth=2)
+        self.assertEqual(list(init), [2, 129])
+        with self.assertWarnsRegex(SyntaxWarning,
+                r"^Initial value 128 will be truncated to the memory shape signed\(8\)$"):
+            init = MemoryData.Init([128], shape=signed(8), depth=1)
+        self.assertEqual(list(init), [-128])
+        with self.assertWarnsRegex(SyntaxWarning,
+                r"^Initial value -129 will be truncated to the memory shape signed\(8\)$"):
+            init = MemoryData.Init([-129], shape=signed(8), depth=1)
+        self.assertEqual(list(init), [127])

--- a/tests/test_lib_memory.py
+++ b/tests/test_lib_memory.py
@@ -329,7 +329,7 @@ class MemoryTestCase(FHDLTestCase):
             memory.Memory(shape="a", depth=3, init=[])
         with self.assertRaisesRegex(TypeError,
                 (r"^Memory initialization value at address 1: "
-                    r"'str' object cannot be interpreted as an integer$")):
+                    r"Initial value must be a constant-castable expression, not '0'$")):
             memory.Memory(shape=8, depth=4, init=[1, "0"])
         with self.assertRaisesRegex(ValueError,
                 r"^Either 'data' or 'shape' needs to be given$"):
@@ -373,7 +373,7 @@ class MemoryTestCase(FHDLTestCase):
     def test_init_set_wrong(self):
         m = memory.Memory(shape=8, depth=4, init=[])
         with self.assertRaisesRegex(TypeError,
-                r"^'str' object cannot be interpreted as an integer$"):
+                r"^Initial value must be a constant-castable expression, not 'a'$"):
             m.init[0] = "a"
         m = memory.Memory(shape=MyStruct, depth=4, init=[])
         # underlying TypeError message differs between PyPy and CPython


### PR DESCRIPTION
Fixes #1492.