### PR TITLE
build.res: allow `dir="-"` when requesting resources with subsignals. [0.5 backport]

### DIFF
--- a/amaranth/build/res.py
+++ b/amaranth/build/res.py
@@ -152,7 +152,8 @@ class ResourceManager:
 
         def merge_options(subsignal, dir, xdr):
             if isinstance(subsignal.ios[0], Subsignal):
-                if dir is None:
+                orig_dir = dir
+                if dir is None or dir == "-":
                     dir = dict()
                 if xdr is None:
                     xdr = dict()
@@ -165,7 +166,7 @@ class ResourceManager:
                                     "has subsignals"
                                     .format(xdr, subsignal))
                 for sub in subsignal.ios:
-                    sub_dir = dir.get(sub.name, None)
+                    sub_dir = "-" if orig_dir == "-" else dir.get(sub.name, None)
                     sub_xdr = xdr.get(sub.name, None)
                     dir[sub.name], xdr[sub.name] = merge_options(sub, sub_dir, sub_xdr)
             else:

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -33,6 +33,14 @@ Standard library changes
 * Added: constants of :class:`amaranth.lib.data.ArrayLayout` are iterable.
 
 
+Platform integration changes
+----------------------------
+
+.. currentmodule:: amaranth.vendor
+
+* Added: :meth:`Platform.request` accepts :py:`dir="-"` for resources with subsignals.
+
+
 Version 0.5.1
 =============
 

--- a/tests/test_build_res.py
+++ b/tests/test_build_res.py
@@ -84,6 +84,12 @@ class ResourceManagerTestCase(FHDLTestCase):
         scl_buffer._MustUse__silence = True
         sda_buffer._MustUse__silence = True
 
+    def test_request_subsignal_dash(self):
+        with _ignore_deprecated():
+            i2c = self.cm.request("i2c", 0, dir="-")
+        self.assertIsInstance(i2c.sda, SingleEndedPort)
+        self.assertIsInstance(i2c.scl, SingleEndedPort)
+
     def test_request_tristate(self):
         with _ignore_deprecated():
             i2c = self.cm.request("i2c", 0)


### PR DESCRIPTION
This makes the only non-deprecated way to do I/O not be a pain when subsignals are involved.