### PR TITLE
Fix handling of CRC start and valid signals

### DIFF
--- a/amaranth/lib/crc/__init__.py
+++ b/amaranth/lib/crc/__init__.py
@@ -346,8 +346,12 @@ class Processor(Elaboratable):
                     if self._matrix_g[j][i]:
                         bit ^= data_in[j]
                 m.d.sync += crc_reg[i].eq(bit)
+            m.d.sync += self.valid.eq(0)
         with m.Elif(self.start):
-            m.d.sync += crc_reg.eq(self._initial_crc)
+            m.d.sync += [
+                crc_reg.eq(self._initial_crc),
+                self.start.eq(0)
+            ]
 
         # Check for residue match, indicating a valid codeword.
         if self._reflect_output:


### PR DESCRIPTION
As of version 0.5.2, the gateware implementation of CRC depends on the user asserting and then de-asserting the `start` and `valid` signals manually after exactly one clock cycle, or else the operation will be executed on each subsequent clock cycle.

This behavior is undesirable as it may be convenient for the user to wait for more than one clock cycle before interfacing with the CRC module again.

This PR automatically resets the `start` and `valid` signals after they have been processed once. Existing implementations which de-assert these signals manually should not be affected by this change.