### PR TITLE
rpc: use rtlil instead of ilang

### DIFF
--- a/amaranth/rpc.py
+++ b/amaranth/rpc.py
@@ -78,7 +78,7 @@ def _serve_yosys(modules):
                         if not port_name.startswith("_") and isinstance(port, Signal):
                             ports += port._lhs_signals()
                 rtlil_text = rtlil.convert(elaboratable, name=module_name, ports=ports)
-                response = {"frontend": "ilang", "source": rtlil_text}
+                response = {"frontend": "rtlil", "source": rtlil_text}
             except Exception as error:
                 response = {"error": f"{type(error).__qualname__}: {str(error)}"}
 


### PR DESCRIPTION
The ilang alias to the rtlil frontend got removed in https://github.com/YosysHQ/yosys/pull/4704