### PR TITLE
back/vendor: s/ilang/rtlil as a result of YosysHQ/yosys#4704

### DIFF
--- a/amaranth/back/cxxrtl.py
+++ b/amaranth/back/cxxrtl.py
@@ -23,8 +23,8 @@ def _convert_rtlil_text(rtlil_text, black_boxes, *, src_loc_at=0):
     script = []
     if black_boxes is not None:
         for box_name, box_source in black_boxes.items():
-            script.append(f"read_ilang <<rtlil\n{box_source}\nrtlil")
-    script.append(f"read_ilang <<rtlil\n{rtlil_text}\nrtlil")
+            script.append(f"read_rtlil <<rtlil\n{box_source}\nrtlil")
+    script.append(f"read_rtlil <<rtlil\n{rtlil_text}\nrtlil")
     script.append("write_cxxrtl")
 
     return yosys.run(["-q", "-"], "\n".join(script), src_loc_at=1 + src_loc_at)

--- a/amaranth/back/verilog.py
+++ b/amaranth/back/verilog.py
@@ -12,7 +12,7 @@ def _convert_rtlil_text(rtlil_text, *, strip_internal_attrs=False, write_verilog
     yosys = find_yosys(lambda ver: ver >= (0, 40))
 
     script = []
-    script.append(f"read_ilang <<rtlil\n{rtlil_text}\nrtlil")
+    script.append(f"read_rtlil <<rtlil\n{rtlil_text}\nrtlil")
     script.append("proc -nomux -norom")
     script.append("memory_collect")
 

--- a/amaranth/vendor/_altera.py
+++ b/amaranth/vendor/_altera.py
@@ -222,7 +222,7 @@ class AlteraPlatform(TemplatedPlatform):
         * ``verbose``: enables logging of informational messages to standard error.
         * ``read_verilog_opts``: adds options for ``read_verilog`` Yosys command.
         * ``synth_opts``: adds options for ``synth_intel_alm`` Yosys command.
-        * ``script_after_read``: inserts commands after ``read_ilang`` in Yosys script.
+        * ``script_after_read``: inserts commands after ``read_rtlil`` in Yosys script.
         * ``script_after_synth``: inserts commands after ``synth_intel_alm`` in Yosys script.
         * ``yosys_opts``: adds extra options for ``yosys``.
         * ``nextpnr_opts``: adds extra options for ``nextpnr-mistral``.
@@ -373,9 +373,9 @@ class AlteraPlatform(TemplatedPlatform):
                 read_verilog -sv {{get_override("read_verilog_opts")|options}} {{file}}
             {% endfor %}
             {% for file in platform.iter_files(".il") -%}
-                read_ilang {{file}}
+                read_rtlil {{file}}
             {% endfor %}
-            read_ilang {{name}}.il
+            read_rtlil {{name}}.il
             {{get_override("script_after_read")|default("# (script_after_read placeholder)")}}
             synth_intel_alm {{get_override("synth_opts")|options}} -top {{name}}
             {{get_override("script_after_synth")|default("# (script_after_synth placeholder)")}}

--- a/amaranth/vendor/_gowin.py
+++ b/amaranth/vendor/_gowin.py
@@ -383,9 +383,9 @@ class GowinPlatform(TemplatedPlatform):
                 read_verilog -sv {{get_override("read_verilog_opts")|options}} {{file}}
             {% endfor %}
             {% for file in platform.iter_files(".il") -%}
-                read_ilang {{file}}
+                read_rtlil {{file}}
             {% endfor %}
-            read_ilang {{name}}.il
+            read_rtlil {{name}}.il
             {{get_override("script_after_read")|default("# (script_after_read placeholder)")}}
             synth_gowin {{get_override("synth_opts")|options}} -top {{name}} -json {{name}}.syn.json
             {{get_override("script_after_synth")|default("# (script_after_synth placeholder)")}}

--- a/amaranth/vendor/_lattice.py
+++ b/amaranth/vendor/_lattice.py
@@ -319,7 +319,7 @@ class LatticePlatform(TemplatedPlatform):
         * ``verbose``: enables logging of informational messages to standard error.
         * ``read_verilog_opts``: adds options for ``read_verilog`` Yosys command.
         * ``synth_opts``: adds options for ``synth_<family>`` Yosys command.
-        * ``script_after_read``: inserts commands after ``read_ilang`` in Yosys script.
+        * ``script_after_read``: inserts commands after ``read_rtlil`` in Yosys script.
         * ``script_after_synth``: inserts commands after ``synth_<family>`` in Yosys script.
         * ``yosys_opts``: adds extra options for ``yosys``.
         * ``nextpnr_opts``: adds extra options for ``nextpnr-<family>``.
@@ -348,7 +348,7 @@ class LatticePlatform(TemplatedPlatform):
         * ``verbose``: enables logging of informational messages to standard error.
         * ``read_verilog_opts``: adds options for ``read_verilog`` Yosys command.
         * ``synth_opts``: adds options for ``synth_nexus`` Yosys command.
-        * ``script_after_read``: inserts commands after ``read_ilang`` in Yosys script.
+        * ``script_after_read``: inserts commands after ``read_rtlil`` in Yosys script.
         * ``script_after_synth``: inserts commands after ``synth_nexus`` in Yosys script.
         * ``yosys_opts``: adds extra options for ``yosys``.
         * ``nextpnr_opts``: adds extra options for ``nextpnr-nexus``.
@@ -474,9 +474,9 @@ class LatticePlatform(TemplatedPlatform):
                 read_verilog -sv {{get_override("read_verilog_opts")|options}} {{file}}
             {% endfor %}
             {% for file in platform.iter_files(".il") -%}
-                read_ilang {{file}}
+                read_rtlil {{file}}
             {% endfor %}
-            read_ilang {{name}}.il
+            read_rtlil {{name}}.il
             {{get_override("script_after_read")|default("# (script_after_read placeholder)")}}
             {% if platform.family == "ecp5" %}
                 synth_ecp5 {{get_override("synth_opts")|options}} -top {{name}}
@@ -566,9 +566,9 @@ class LatticePlatform(TemplatedPlatform):
                 read_verilog -sv {{get_override("read_verilog_opts")|options}} {{file}}
             {% endfor %}
             {% for file in platform.iter_files(".il") -%}
-                read_ilang {{file}}
+                read_rtlil {{file}}
             {% endfor %}
-            read_ilang {{name}}.il
+            read_rtlil {{name}}.il
             delete w:$verilog_initial_trigger
             {{get_override("script_after_read")|default("# (script_after_read placeholder)")}}
             synth_nexus {{get_override("synth_opts")|options}} -top {{name}}

--- a/amaranth/vendor/_siliconblue.py
+++ b/amaranth/vendor/_siliconblue.py
@@ -27,7 +27,7 @@ class SiliconBluePlatform(TemplatedPlatform):
         * ``verbose``: enables logging of informational messages to standard error.
         * ``read_verilog_opts``: adds options for ``read_verilog`` Yosys command.
         * ``synth_opts``: adds options for ``synth_ice40`` Yosys command.
-        * ``script_after_read``: inserts commands after ``read_ilang`` in Yosys script.
+        * ``script_after_read``: inserts commands after ``read_rtlil`` in Yosys script.
         * ``script_after_synth``: inserts commands after ``synth_ice40`` in Yosys script.
         * ``yosys_opts``: adds extra options for ``yosys``.
         * ``nextpnr_opts``: adds extra options for ``nextpnr-ice40``.
@@ -122,9 +122,9 @@ class SiliconBluePlatform(TemplatedPlatform):
                 read_verilog -sv {{get_override("read_verilog_opts")|options}} {{file}}
             {% endfor %}
             {% for file in platform.iter_files(".il") -%}
-                read_ilang {{file}}
+                read_rtlil {{file}}
             {% endfor %}
-            read_ilang {{name}}.il
+            read_rtlil {{name}}.il
             {{get_override("script_after_read")|default("# (script_after_read placeholder)")}}
             synth_ice40 {{get_override("synth_opts")|options}} -top {{name}}
             {{get_override("script_after_synth")|default("# (script_after_synth placeholder)")}}

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -104,7 +104,7 @@ class FHDLTestCase(unittest.TestCase):
         smtbmc
 
         [script]
-        read_ilang top.il
+        read_rtlil top.il
         prep
         {script}
 


### PR DESCRIPTION
https://github.com/amaranth-lang/amaranth/pull/1540 did not catch all uses of this command that was deprecated upstream in https://github.com/YosysHQ/yosys/pull/4704