### PR TITLE
Fix repr of Signature so it works for subclasses

### DIFF
--- a/amaranth/lib/wiring.py
+++ b/amaranth/lib/wiring.py
@@ -1002,7 +1002,7 @@ class Signature(metaclass=SignatureMeta):
         return tuple()
 
     def __repr__(self):
-        if type(self) is Signature:
+        if isinstance(self, Signature):
             return f"Signature({dict(self.members.items())})"
         return super().__repr__()
 


### PR DESCRIPTION
At the moment the `__repr__` for `Signature` doesn't work for derived classes of `Signature` (as used e.g. in Glasgow).

Simple fix here.