### PR TITLE
fix: error in invoke_tool when running vivado.bat on Windows

### DIFF
--- a/amaranth/build/plat.py
+++ b/amaranth/build/plat.py
@@ -338,7 +338,7 @@ class TemplatedPlatform(Platform):
             if context.parent["syntax"] == "sh":
                 return f"\"${env_var}\""
             elif context.parent["syntax"] == "bat":
-                return f"\"%{env_var}%\""
+                return f"call %{env_var}%"
             else:
                 assert False
 


### PR DESCRIPTION
# Amaranth version

0.5.3

# minimal program that demonstrates

- OS: Windows 11
- PATH includes:  `C:\xilinx\Vivado\2024.2\bin`, `C:\xilinx\Vivado\2024.2\xsct-trim\bin`

run `ArtyA7_35Platform().build(Blinky(), do_build=True, do_program=True)`


```bat
'"E:\repos\bonsai\build/setupEnv.bat"' は、内部コマンドまたは外部コマンド、
操作可能なプログラムまたはバッチ ファイルとして認識されていません。
'"/setupEnv.bat"' は、内部コマンドまたは外部コマンド、
操作可能なプログラムまたはバッチ ファイルとして認識されていません。
'"/loader.bat"' は、内部コマンドまたは外部コマンド、
操作可能なプログラムまたはバッチ ファイルとして認識されていません。
Traceback (most recent call last):
  File "E:\repos\bonsai\bonsai\cli.py", line 63, in <module>
    main()
  File "E:\repos\bonsai\bonsai\cli.py", line 57, in main
    test_arty_a7_35_platform()
  File "E:\repos\bonsai\bonsai\cli.py", line 30, in test_arty_a7_35_platform
    ArtyA7_35Platform().build(Blinky(), do_build=True, do_program=True)
  File "E:\repos\bonsai\.venv\Lib\site-packages\amaranth\build\plat.py", line 103, in build
    products = plan.execute_local(build_dir)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "E:\repos\bonsai\.venv\Lib\site-packages\amaranth\build\run.py", line 115, in execute_local
    subprocess.check_call(["cmd", "/c", f"call {self.script}.bat"],
  File "C:\Users\user\AppData\Local\Programs\Python\Python312\Lib\subprocess.py", line 413, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['cmd', '/c', 'call build_top.bat']' returned non-zero exit status 1.
```

# What you expected to happen, and what actually happened

The problem seems to be caused by vivado.bat on Windows.
Here is the result of my experiment by modifying the `build_{name}`.bat generated by platform.py.

```diff
@rem Automatically generated by Amaranth 0.5.3.
@echo off
SetLocal EnableDelayedExpansion
if defined AMARANTH_ENV_VIVADO call “%AMARANTH_ENV_VIVADO%”
if [!VIVADO!] equ [“”] set VIVADO=
if [!VIVADO!] equ [“”] set VIVADO=vivado

-“%VIVADO%” -mode batch -log top.log -source top.tcl || exit /b
+%VIVADO% -mode batch -log top.log -source top.tcl || exit /b
```

I am not familiar with batch files, but there seems to be a behavior difference between calling `vivado` and `“vivado”`.

In the invoked `vivado.bat`, `pushd “%~dp0”` failed to move to the `vivado.bat` directory and `_RDI_BINROOT` became invalid and vivado did not run as expected.

However, the fix to remove the double quotes did not work properly in cases where the full path to `vivado.bat` was manually specified in `VIVADO` and there was a blank space, so the fix is `call %VIVADO%`.
