### PR TITLE
fix: pip install “amaransh[builtin-yosys] @ git+<repo url>” failed

### DIFF
--- a/pdm_build.py
+++ b/pdm_build.py
@@ -5,7 +5,14 @@ from pdm.backend._vendor.packaging.version import Version
 
 
 def format_version(version: SCMVersion) -> str:
-    major, minor, patch = (int(n) for n in str(version.version).split(".")[:3])
+
+    # SCMVersion
+    # Note: There are cases where `Version('0.0')` is obtained when specified via git.
+    semver_tokens =list([int(n) for n in str(version.version).split(".")])
+    if len(semver_tokens) < 3:
+        semver_tokens += [0] * (3 - len(semver_tokens))
+    major, minor, patch = semver_tokens
+
     dirty = f"+{datetime.utcnow():%Y%m%d.%H%M%S}" if version.dirty else ""
     if version.distance is None:
         return f"{major}.{minor}.{patch}{dirty}"


### PR DESCRIPTION
# Amaranth version

0.5.3

# minimal program that demonstrates

When I try to reference the forked amaranth repository, it fails with an error in `pdm_build.py`.

```sh
uv pip install "amaranth[builtin-yosys] @ git+https://github.com/wipeseals/amaranth.git"     
 Updated https://github.com/wipeseals/amaranth.git (e57bade)
  × Failed to download and build `amaranth @ git+https://github.com/wipeseals/amaranth.git`
  ╰─▶ Build backend failed to determine metadata through `prepare_metadata_for_build_wheel` (exit code: 1)

      [stderr]
      Traceback (most recent call last):
        File "<string>", line 14, in <module>
        File "C:\Users\user\AppData\Local\uv\cache\builds-v0\.tmptDMKQz\Lib\site-packages\pdm\backend\__init__.py", line 43, in prepare_metadata_for_build_wheel
          return builder.prepare_metadata(metadata_directory).name
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "C:\Users\user\AppData\Local\uv\cache\builds-v0\.tmptDMKQz\Lib\site-packages\pdm\backend\wheel.py", line 102, in prepare_metadata
          self.initialize(context)
        File "C:\Users\user\AppData\Local\uv\cache\builds-v0\.tmptDMKQz\Lib\site-packages\pdm\backend\base.py", line 194, in initialize
          self.call_hook("pdm_build_initialize", context)
        File "C:\Users\user\AppData\Local\uv\cache\builds-v0\.tmptDMKQz\Lib\site-packages\pdm\backend\base.py", line 152, in call_hook
          getattr(hook, hook_name)(context, *args, **kwargs)
        File "C:\Users\user\AppData\Local\uv\cache\builds-v0\.tmptDMKQz\Lib\site-packages\pdm\backend\hooks\version\__init__.py", line 53, in pdm_build_initialize
          metadata["version"] = getattr(self, f"resolve_version_from_{source}")(
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "C:\Users\user\AppData\Local\uv\cache\builds-v0\.tmptDMKQz\Lib\site-packages\pdm\backend\hooks\version\__init__.py", line 91, in resolve_version_from_scm
          version = get_version_from_scm(
                    ^^^^^^^^^^^^^^^^^^^^^
        File "C:\Users\user\AppData\Local\uv\cache\builds-v0\.tmptDMKQz\Lib\site-packages\pdm\backend\hooks\version\scm.py", line 348, in get_version_from_scm
          return version_formatter(version)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "C:\Users\user\AppData\Local\uv\cache\git-v0\checkouts\9e6b10ec7f5a559a\e57bade\pdm_build.py", line 8, in format_version
          major, minor, patch = (int(n) for n in str(version.version).split(".")[:3])
          ^^^^^^^^^^^^^^^^^^^
      ValueError: not enough values to unpack (expected 3, got 2)
```

# What you expected to happen, and what actually happened

The implementation assumes that str(`SCMVersion#version`) contains a SemVer (“major.minor.patch”) format value, but there were cases where the patch version was missing, as shown below.


```log
      [stdout]
      SCMVersion(version=<Version('0.0')>, distance=1801, dirty=True, node='ge57bade', branch='master')
```