### PR TITLE
vendor._gowin: fix comment syntax for add_preferences

### DIFF
--- a/amaranth/vendor/_gowin.py
+++ b/amaranth/vendor/_gowin.py
@@ -352,7 +352,7 @@ class GowinPlatform(TemplatedPlatform):
                     IO_PORT "{{port_name}}" {{attr_name}}={{attr_value}};
                 {% endfor %}
             {% endfor %}
-            {{get_override("add_preferences")|default("# (add_preferences placeholder)")}}
+            {{get_override("add_preferences")|default("// (add_preferences placeholder)")}}
         """,
     }
 


### PR DESCRIPTION
# Amaranth version

0.6.0.dev76

# minimal program that demonstrates

run `TangNano9kPlatform().build(AnyElaboratableClass(), do_program=True)`

```sh
Warning: Invalid constraint: # (add_preferences placeholder)
1 warning, 0 errors
```
# What you expected to happen, and what actually happened

Tracing the cause from the error logs, the problem is probably in the commented out text appended by default in `add_preferences`.

The IO constraints file (.cst) in the gowin platform handles commentouts with `//`, but `add_preferences` handles them with `#`.

I assume that it is probably mistaken for commentout in .ys.

```cst
// Automatically generated by Amaranth 0.6.0.dev76. Do not edit.
IO_LOC “clk27_0__io” 52;
IO_PORT “clk27_0__io” IO_TYPE=LVCMOS33;

(snip)

IO_LOC “button_1__io” 4; ...
IO_PORT “button_1__io” IO_TYPE=LVCMOS33;
IO_LOC “uart_0__tx__io” 17;
IO_PORT “uart_0__tx__io” PULL_MODE=UP;
IO_PORT “uart_0__tx__io” IO_TYPE=LVCMOS33;
# (add_preferences placeholder)
```



