### PR TITLE
backends: s/ilang/rtlil as a result of YosysHQ/yosys#4704

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,12 +11,10 @@ jobs:
     strategy:
       matrix:
         python-version:
-        - '3.8'
         - '3.9'
         - '3.10'
         - '3.11'
         - '3.12'
-        - 'pypy-3.8'
         - 'pypy-3.9'
         - 'pypy-3.10'
         allow-failure:

--- a/amaranth/back/cxxrtl.py
+++ b/amaranth/back/cxxrtl.py
@@ -23,8 +23,8 @@ def _convert_rtlil_text(rtlil_text, black_boxes, *, src_loc_at=0):
     script = []
     if black_boxes is not None:
         for box_name, box_source in black_boxes.items():
-            script.append(f"read_ilang <<rtlil\n{box_source}\nrtlil")
-    script.append(f"read_ilang <<rtlil\n{rtlil_text}\nrtlil")
+            script.append(f"read_rtlil <<rtlil\n{box_source}\nrtlil")
+    script.append(f"read_rtlil <<rtlil\n{rtlil_text}\nrtlil")
     script.append("write_cxxrtl")
 
     return yosys.run(["-q", "-"], "\n".join(script), src_loc_at=1 + src_loc_at)

--- a/amaranth/back/verilog.py
+++ b/amaranth/back/verilog.py
@@ -12,7 +12,7 @@ def _convert_rtlil_text(rtlil_text, *, strip_internal_attrs=False, write_verilog
     yosys = find_yosys(lambda ver: ver >= (0, 38))
 
     script = []
-    script.append(f"read_ilang <<rtlil\n{rtlil_text}\nrtlil")
+    script.append(f"read_rtlil <<rtlil\n{rtlil_text}\nrtlil")
     script.append("proc -nomux -norom")
     script.append("memory_collect")
 

--- a/amaranth/vendor/_gowin.py
+++ b/amaranth/vendor/_gowin.py
@@ -224,9 +224,9 @@ class GowinPlatform(TemplatedPlatform):
                 read_verilog -sv {{get_override("read_verilog_opts")|options}} {{file}}
             {% endfor %}
             {% for file in platform.iter_files(".il") -%}
-                read_ilang {{file}}
+                read_rtlil {{file}}
             {% endfor %}
-            read_ilang {{name}}.il
+            read_rtlil {{name}}.il
             {{get_override("script_after_read")|default("# (script_after_read placeholder)")}}
             synth_gowin {{get_override("synth_opts")|options}} -top {{name}} -json {{name}}.syn.json
             {{get_override("script_after_synth")|default("# (script_after_synth placeholder)")}}

--- a/amaranth/vendor/_intel.py
+++ b/amaranth/vendor/_intel.py
@@ -44,7 +44,7 @@ class IntelPlatform(TemplatedPlatform):
         * ``verbose``: enables logging of informational messages to standard error.
         * ``read_verilog_opts``: adds options for ``read_verilog`` Yosys command.
         * ``synth_opts``: adds options for ``synth_intel_alm`` Yosys command.
-        * ``script_after_read``: inserts commands after ``read_ilang`` in Yosys script.
+        * ``script_after_read``: inserts commands after ``read_rtlil`` in Yosys script.
         * ``script_after_synth``: inserts commands after ``synth_intel_alm`` in Yosys script.
         * ``yosys_opts``: adds extra options for ``yosys``.
         * ``nextpnr_opts``: adds extra options for ``nextpnr-mistral``.
@@ -194,9 +194,9 @@ class IntelPlatform(TemplatedPlatform):
                 read_verilog -sv {{get_override("read_verilog_opts")|options}} {{file}}
             {% endfor %}
             {% for file in platform.iter_files(".il") -%}
-                read_ilang {{file}}
+                read_rtlil {{file}}
             {% endfor %}
-            read_ilang {{name}}.il
+            read_rtlil {{name}}.il
             {{get_override("script_after_read")|default("# (script_after_read placeholder)")}}
             synth_intel_alm {{get_override("synth_opts")|options}} -top {{name}}
             {{get_override("script_after_synth")|default("# (script_after_synth placeholder)")}}

--- a/amaranth/vendor/_lattice_ecp5.py
+++ b/amaranth/vendor/_lattice_ecp5.py
@@ -20,7 +20,7 @@ class LatticeECP5Platform(TemplatedPlatform):
         * ``verbose``: enables logging of informational messages to standard error.
         * ``read_verilog_opts``: adds options for ``read_verilog`` Yosys command.
         * ``synth_opts``: adds options for ``synth_ecp5`` Yosys command.
-        * ``script_after_read``: inserts commands after ``read_ilang`` in Yosys script.
+        * ``script_after_read``: inserts commands after ``read_rtlil`` in Yosys script.
         * ``script_after_synth``: inserts commands after ``synth_ecp5`` in Yosys script.
         * ``yosys_opts``: adds extra options for ``yosys``.
         * ``nextpnr_opts``: adds extra options for ``nextpnr-ecp5``.
@@ -114,9 +114,9 @@ class LatticeECP5Platform(TemplatedPlatform):
                 read_verilog -sv {{get_override("read_verilog_opts")|options}} {{file}}
             {% endfor %}
             {% for file in platform.iter_files(".il") -%}
-                read_ilang {{file}}
+                read_rtlil {{file}}
             {% endfor %}
-            read_ilang {{name}}.il
+            read_rtlil {{name}}.il
             {{get_override("script_after_read")|default("# (script_after_read placeholder)")}}
             synth_ecp5 {{get_override("synth_opts")|options}} -top {{name}}
             {{get_override("script_after_synth")|default("# (script_after_synth placeholder)")}}

--- a/amaranth/vendor/_lattice_ice40.py
+++ b/amaranth/vendor/_lattice_ice40.py
@@ -21,7 +21,7 @@ class LatticeICE40Platform(TemplatedPlatform):
         * ``verbose``: enables logging of informational messages to standard error.
         * ``read_verilog_opts``: adds options for ``read_verilog`` Yosys command.
         * ``synth_opts``: adds options for ``synth_ice40`` Yosys command.
-        * ``script_after_read``: inserts commands after ``read_ilang`` in Yosys script.
+        * ``script_after_read``: inserts commands after ``read_rtlil`` in Yosys script.
         * ``script_after_synth``: inserts commands after ``synth_ice40`` in Yosys script.
         * ``yosys_opts``: adds extra options for ``yosys``.
         * ``nextpnr_opts``: adds extra options for ``nextpnr-ice40``.
@@ -116,9 +116,9 @@ class LatticeICE40Platform(TemplatedPlatform):
                 read_verilog -sv {{get_override("read_verilog_opts")|options}} {{file}}
             {% endfor %}
             {% for file in platform.iter_files(".il") -%}
-                read_ilang {{file}}
+                read_rtlil {{file}}
             {% endfor %}
-            read_ilang {{name}}.il
+            read_rtlil {{name}}.il
             {{get_override("script_after_read")|default("# (script_after_read placeholder)")}}
             synth_ice40 {{get_override("synth_opts")|options}} -top {{name}}
             {{get_override("script_after_synth")|default("# (script_after_synth placeholder)")}}

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -6,7 +6,7 @@ System requirements
 
 .. |yosys-version| replace:: 0.35 (or newer)
 
-Amaranth HDL requires Python 3.8; it works on CPython_ 3.8 (or newer), and works faster on PyPy3.8_ 7.3.7 (or newer). Installation requires pip_ 23.0 (or newer).
+Amaranth HDL requires Python 3.9; it works on CPython_ 3.9 (or newer), and works faster on PyPy3.9_ 7.3.7 (or newer). Installation requires pip_ 23.0 (or newer).
 
 For most workflows, Amaranth requires Yosys_ |yosys-version|. A compatible version of Yosys is distributed via PyPI_ for most popular platforms.
 
@@ -17,8 +17,8 @@ Synthesizing, placing and routing an Amaranth design for an FPGA requires the FP
 .. TODO: Link to FPGA family docs here
 
 .. _CPython: https://www.python.org/
-.. _PyPy3.8: https://www.pypy.org/
-.. _pip: https://pip.pypa.io/
+.. _PyPy3.9: https://www.pypy.org/
+.. _pip: https://pip.pypa.io/en/stable/
 .. _Yosys: https://yosyshq.net/yosys/
 .. _PyPI: https://pypi.org/
 .. _GTKWave: http://gtkwave.sourceforge.net/

--- a/docs/lang.rst
+++ b/docs/lang.rst
@@ -173,6 +173,14 @@ Specifying a shape with a range is convenient for counters, indexes, and all oth
    Python ranges are *exclusive* or *half-open*, meaning they do not contain their ``.stop`` element. Because of this, values with shapes cast from a ``range(stop)`` where ``stop`` is a power of 2 are not wide enough to represent ``stop`` itself:
 
    .. doctest::
+      :hide:
+
+      >>> import warnings
+      >>> _warning_filters_backup = warnings.catch_warnings()
+      >>> _warning_filters_backup.__enter__() # have to do this horrific hack to make it work with `PYTHONWARNINGS=error` :(
+      >>> warnings.simplefilter("default", SyntaxWarning)
+
+   .. doctest::
 
       >>> fencepost = C(256, range(256))
       <...>:1: SyntaxWarning: Value 256 equals the non-inclusive end of the constant shape range(0, 256); this is likely an off-by-one error
@@ -181,6 +189,11 @@ Specifying a shape with a range is convenient for counters, indexes, and all oth
       unsigned(8)
       >>> fencepost.value
       0
+
+   .. doctest::
+      :hide:
+
+      >>> _warning_filters_backup.__exit__()
 
    Amaranth detects uses of :class:`Const` and :class:`Signal` that invoke such an off-by-one error, and emits a diagnostic message.
 
@@ -678,6 +691,14 @@ Python expression Amaranth expression (boolean operands)
    When applied to Amaranth boolean values, the ``~`` operator computes negation, and when applied to Python boolean values, the ``not`` operator also computes negation. However, the ``~`` operator applied to Python boolean values produces an unexpected result:
 
    .. doctest::
+      :hide:
+
+      >>> import warnings
+      >>> _warning_filters_backup = warnings.catch_warnings()
+      >>> _warning_filters_backup.__enter__() # have to do this horrific hack to make it work with `PYTHONWARNINGS=error` :(
+      >>> warnings.simplefilter("ignore", DeprecationWarning)
+
+   .. doctest::
 
       >>> ~False
       -1
@@ -694,6 +715,11 @@ Python expression Amaranth expression (boolean operands)
       (| (const 1'd0) (sig stb))
       >>> ~use_stb | stb # WRONG! MSB of 2-bit wide OR expression is always 1
       (| (const 2'sd-2) (sig stb))
+
+   .. doctest::
+      :hide:
+
+      >>> _warning_filters_backup.__exit__()
 
    Amaranth automatically detects some cases of misuse of ``~`` and emits a detailed diagnostic message.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ test = [
 docs = [
   "sphinx~=7.1",
   "sphinxcontrib-platformpicker~=1.3",
-  "sphinx-rtd-theme~=1.2",
+  "sphinx-rtd-theme~=2.0",
   "sphinx-autobuild",
 ]
 examples = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,8 @@ readme = "README.md"
 authors = [{name = "Amaranth HDL contributors"}]
 license = {file = "LICENSE.txt"}
 
-requires-python = "~=3.8"
+requires-python = "~=3.9"
 dependencies = [
-  "importlib_resources; python_version<'3.9'", # for amaranth._toolchain.yosys
   "pyvcd>=0.2.2,<0.5", # for amaranth.sim.pysim
   "Jinja2~=3.0", # for amaranth.build
 ]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -62,7 +62,7 @@ class FHDLTestCase(unittest.TestCase):
         smtbmc
 
         [script]
-        read_ilang top.il
+        read_rtlil top.il
         prep
         {script}
 


### PR DESCRIPTION
Replace all occurrences of `read_ilang` with `read_rtlil`.

Backported from https://github.com/amaranth-lang/amaranth/commit/590cba1d6c00dffba7abb5f399680ac50e252adf into v0.4.x