### PR TITLE
Drop support for Python 3.8.

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,12 +11,10 @@ jobs:
     strategy:
       matrix:
         python-version:
-        - '3.8'
         - '3.9'
         - '3.10'
         - '3.11'
         - '3.12'
-        - 'pypy-3.8'
         - 'pypy-3.9'
         - 'pypy-3.10'
         allow-failure:

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -6,7 +6,7 @@ System requirements
 
 .. |yosys-version| replace:: 0.35 (or newer)
 
-Amaranth HDL requires Python 3.8; it works on CPython_ 3.8 (or newer), and works faster on PyPy3.8_ 7.3.7 (or newer). Installation requires pip_ 23.0 (or newer).
+Amaranth HDL requires Python 3.9; it works on CPython_ 3.9 (or newer), and works faster on PyPy3.9_ 7.3.7 (or newer). Installation requires pip_ 23.0 (or newer).
 
 For most workflows, Amaranth requires Yosys_ |yosys-version|. A compatible version of Yosys is distributed via PyPI_ for most popular platforms.
 
@@ -17,8 +17,8 @@ Synthesizing, placing and routing an Amaranth design for an FPGA requires the FP
 .. TODO: Link to FPGA family docs here
 
 .. _CPython: https://www.python.org/
-.. _PyPy3.8: https://www.pypy.org/
-.. _pip: https://pip.pypa.io/
+.. _PyPy3.9: https://www.pypy.org/
+.. _pip: https://pip.pypa.io/en/stable/
 .. _Yosys: https://yosyshq.net/yosys/
 .. _PyPI: https://pypi.org/
 .. _GTKWave: http://gtkwave.sourceforge.net/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,8 @@ readme = "README.md"
 authors = [{name = "Amaranth HDL contributors"}]
 license = {file = "LICENSE.txt"}
 
-requires-python = "~=3.8"
+requires-python = "~=3.9"
 dependencies = [
-  "importlib_resources; python_version<'3.9'", # for amaranth._toolchain.yosys
   "pyvcd>=0.2.2,<0.5", # for amaranth.sim.pysim
   "Jinja2~=3.0", # for amaranth.build
 ]


### PR DESCRIPTION
Drop support for Python 3.8: documentation, pyproject.toml and GitHub Actions updates.

Required by https://github.com/amaranth-lang/amaranth/pull/1575