### PR TITLE
CI: add pypy-3.11

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,6 +18,7 @@ jobs:
         - '3.13'
         - 'pypy-3.9'
         - 'pypy-3.10'
+        - 'pypy-3.11'
         allow-failure:
         - false
         include:


### PR DESCRIPTION
Currently fails due to tracer issues.