### PR TITLE
sim: call `.aclose()` on `TickTrigger` in `.until()` and `.repeat()`

### DIFF
--- a/amaranth/sim/_async.py
+++ b/amaranth/sim/_async.py
@@ -362,12 +362,15 @@ class TickTrigger:
                 raise TypeError(f"The shape of a condition may only be `signed` or `unsigned`, "
                                 f"not {shape!r}")
         tick = self.sample(condition).__aiter__()
-        done = False
-        while not done:
-            clk, rst, *values, done = await tick.__anext__()
-            if rst:
-                raise DomainReset
-        return tuple(values)
+        try:
+            done = False
+            while not done:
+                clk, rst, *values, done = await tick.__anext__()
+                if rst:
+                    raise DomainReset
+            return tuple(values)
+        finally:
+            await tick.aclose()
 
     async def repeat(self, count: int):
         """Repeat this trigger a specific number of times.
@@ -400,12 +403,15 @@ class TickTrigger:
         if count <= 0:
             raise ValueError(f"Repeat count must be a positive integer, not {count!r}")
         tick = self.__aiter__()
-        for _ in range(count):
-            clk, rst, *values = await tick.__anext__()
-            if rst:
-                raise DomainReset
-            assert clk
-        return tuple(values)
+        try:
+            for _ in range(count):
+                clk, rst, *values = await tick.__anext__()
+                if rst:
+                    raise DomainReset
+                assert clk
+            return tuple(values)
+        finally:
+            await tick.aclose()
 
     def _collect_trigger(self):
         clk_polarity = (1 if self._domain.clk_edge == "pos" else 0)


### PR DESCRIPTION
Otherwise, when used together with asyncio, the following warning will be printed for each use of `.until()`/`.repeat()`:

    E: asyncio: Task was destroyed but it is pending!
    task: <Task pending name='Task-2' coro=<<async_generator_athrow without __name__>()>>
    /usr/lib/python3.13/asyncio/base_events.py:744: RuntimeWarning: coroutine method 'aclose' of 'TickTrigger.__aiter__' was never awaited