### PR TITLE
tracer: fix on pypy-3.11

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,6 +18,7 @@ jobs:
         - '3.13'
         - 'pypy-3.9'
         - 'pypy-3.10'
+        - 'pypy-3.11'
         allow-failure:
         - false
         include:

--- a/amaranth/tracer.py
+++ b/amaranth/tracer.py
@@ -1,4 +1,5 @@
 import sys
+import platform
 from opcode import opname
 
 
@@ -44,13 +45,13 @@ def get_var_name(depth=2, default=_raise_exception):
             return code.co_names[imm]
         elif opc == "STORE_FAST":
             imm |= int(code.co_code[index + 1])
-            if sys.version_info >= (3, 11):
+            if sys.version_info >= (3, 11) and platform.python_implementation() == 'CPython':
                 return code._varname_from_oparg(imm)
             else:
                 return code.co_varnames[imm]
         elif opc == "STORE_DEREF":
             imm |= int(code.co_code[index + 1])
-            if sys.version_info >= (3, 11):
+            if sys.version_info >= (3, 11) and platform.python_implementation() == 'CPython':
                 return code._varname_from_oparg(imm)
             else:
                 if imm < len(code.co_cellvars):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,9 @@
 import os
+import platform
 import re
 import shutil
 import subprocess
+import sys
 import textwrap
 import traceback
 import unittest
@@ -69,6 +71,9 @@ class FHDLTestCase(unittest.TestCase):
         self.assertEqual(format_repr(squish_repr(repr(obj))), format_repr(squish_repr(repr_str)))
 
     def assertFormal(self, spec, ports=None, mode="bmc", depth=1):
+        if sys.version_info >= (3, 11) and platform.python_implementation() == 'PyPy':
+            self.skipTest("sby is broken with pypy-3.11 without https://github.com/YosysHQ/sby/pull/323")
+
         stack = traceback.extract_stack()
         for frame in reversed(stack):
             if os.path.dirname(__file__) not in frame.filename:


### PR DESCRIPTION
pypy does not have _varname_from_oparg, so fall back to pre cpython-3.11 path 

ref: https://github.com/pypy/pypy/blob/0253c85bf5f86a45760eda7f0af8953ed8a253c7/lib-python/3/dis.py#L351