### PR TITLE
Update document for `ResetSynchronizer`

### DIFF
--- a/amaranth/lib/cdc.py
+++ b/amaranth/lib/cdc.py
@@ -220,8 +220,8 @@ class ResetSynchronizer(Elaboratable):
 
     Platform overrides
     ------------------
-    Define the ``get_reset_sync`` platform method to override the implementation of
-    :class:`ResetSynchronizer`, e.g. to instantiate library cells directly.
+    This uses :class:`AsyncFFSynchronizer` internally and can be overridden
+    with ``get_async_ff_sync``.
     """
     def __init__(self, arst, *, domain="sync", stages=2, max_input_delay=None):
         _check_stages(stages)


### PR DESCRIPTION
Remove reference of out-dated platform method and point to `AsyncFFSynchronizer` instead.

Fix #1605

I kept this in the Platform override section since it seems that this info is only relevant for this part.
