### PR TITLE
docs: include the latest version in the switcher.

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -199,25 +199,41 @@ jobs:
           git clone --depth=1 git@github.com:amaranth-lang/amaranth-lang.github.io.git ~/amaranth-lang.github.io
           cd ~/amaranth-lang.github.io/docs/amaranth/
 
-          (
-          venv_path=$(mktemp -d)
+          venv_path=~/.generate-versions-json-venv
           python3 -m venv "$venv_path"
           source "$venv_path"/bin/activate
           pip install packaging
-          python >versions.json <<EOF
+
+          python <<EOF
+          import re
           import json
           from pathlib import Path
           from packaging.version import Version
 
-          versions = Path('.').glob('v*')
-          versions = (path.name[1:] for path in versions if path.is_dir())
-          versions = sorted(versions, key=Version, reverse=True)
-          versions = ({"name": version, "root_url": f"/docs/amaranth/v{version}/"} for version in versions)
-          print(json.dumps(list(versions), indent=2))
-          EOF
-          )
+          versions = []
+          for version_dir in [Path("latest"), *Path(".").glob("v*")]:
+            if not version_dir.is_dir():
+              continue
+            with open(version_dir / "_static" / "documentation_options.js", "r") as f:
+              doc_options = f.read()
+            match = re.search(r"""VERSION:\s+(['"])(.+?)\1""", doc_options)
+            if match is None:
+              continue
+            versions.append({
+              "name": match.group(2),
+              "root_url": f"/docs/amaranth/{version_dir.name}/",
+            })
 
-          git add versions.json
+          versions.sort(key=lambda x: Version(x["name"]), reverse=True)
+
+          if len(versions) > 0:
+            with open("versions.json", "w") as f:
+              json.dump(versions, f, indent=2)
+          else:
+            Path("versions.json").unlink()
+          EOF
+
+          [[ -f versions.json ]] && git add versions.json || git rm versions.json || true
           if ! git diff-index --quiet --cached HEAD; then
             git \
               -c user.name="$GITHUB_ACTOR" \

--- a/docs/_static/version-switch.js
+++ b/docs/_static/version-switch.js
@@ -5,6 +5,11 @@ document.addEventListener('DOMContentLoaded', () => {
   );
 
   function insertVersionSwitch(versions) {
+    let currentVersion = DOCUMENTATION_OPTIONS.VERSION;
+    if (!versions.some(({ name }) => name === currentVersion)) {
+      return;
+    }
+
     let versionElement = document.querySelector('.wy-side-nav-search > .version');
     if (!versionElement) return;
 
@@ -71,14 +76,6 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     `);
     document.adoptedStyleSheets.push(cssStyleSheet);
-
-    let currentVersion = DOCUMENTATION_OPTIONS.VERSION;
-    if (!versions.some(({ name }) => name === currentVersion)) {
-      versions = [
-        { name: currentVersion, root_url: contentRoot },
-        ...versions,
-      ];
-    }
 
     for (let { name, root_url: rootURL } of versions) {
       rootURL = new URL(rootURL, window.location.href);


### PR DESCRIPTION
This addresses an issue where, if the user navigates to the documentation site for the latest version (`/docs/amaranth/latest/`), an extraneous entry will be prepended to the version list that matches the currently open version but does not show up in docs for other versions (e.g. `/docs/amaranth/v1.2.3/`).

This patch adds an entry for the latest version at build time and removes the behavior where an extraneous entry would be prepended to the version list if no entry that matches the currently open version is present.