### PR TITLE
vendor._siliconblue: fix off-by-1 with `default_clk = "SB_LFOSC"`

### DIFF
--- a/amaranth/vendor/_siliconblue.py
+++ b/amaranth/vendor/_siliconblue.py
@@ -408,7 +408,7 @@ class SiliconBluePlatform(TemplatedPlatform):
 
             # Power-on-reset domain
             m.domains += ClockDomain("por", reset_less=True, local=True)
-            timer = Signal(range(delay))
+            timer = Signal(range(delay + 1))
             ready = Signal()
             m.d.comb += ClockSignal("por").eq(clk_i)
             with m.If(timer == delay):


### PR DESCRIPTION
This bug caused all logic in the `sync` domain to be optimized out, as the reset ended up being continuously asserted.