### PR TITLE
Fix for "Supplied part name is invalid" GW5AST-LV138PG484AC1/I0 

### DIFF
--- a/amaranth/vendor/_gowin.py
+++ b/amaranth/vendor/_gowin.py
@@ -45,9 +45,9 @@ class GowinPlatform(TemplatedPlatform):
 
     def parse_part(self):
         # These regular expressions match all >900 parts of Gowin device_info.csv
-        reg_series    = r"(GW[12]{1}[AN]{1}[EFNRSZ]{0,3})-"
+        reg_series    = r"(GW[125]{1}[AN]{1}[EFNRSZT]{0,3})-"
         reg_voltage   = r"(ZV|EV|LV|LX|UV|UX)"
-        reg_size      = r"(1|2|4|9|18|55)"
+        reg_size      = r"(1|2|4|9|18|55|138)"
         reg_subseries = r"(?:(B|C|S|X|P5)?)"
         reg_package   = r"((?:PG|UG|EQ|LQ|MG|M|QN|CS|FN)(?:\d+)(?:P?)(?:A|E|M|CF|C|D|G|H|F|S|T|U|X)?)"
         reg_speed     = r"((?:C\d{1}/I\d{1})|ES|A\d{1}|I\d{1})"


### PR DESCRIPTION
I have bought Tang Mega 138k. It contains GW5AST-LV138PG484AC1/I0 FPGA IC (I have prepared tang_mega_138k board definition and I'd like to contribute it separately). 

When compiling blinky example

I see following error:
Traceback (most recent call last):
  File "/home/user/Mega138k/1_Blinky/./blinky.py", line 25, in <module>
    platform = TangMega138kPlatform(toolchain='Gowin')
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/oss-cad-suite/lib/python3.11/site-packages/amaranth/vendor/_gowin.py", line 473, in __init__
    self.parse_part()
  File "/oss-cad-suite/lib/python3.11/site-packages/amaranth/vendor/_gowin.py", line 215, in parse_part
    raise ValueError("Supplied part name is invalid")
ValueError: Supplied part name is invalid
