### PR TITLE
gowin: Add support for GW5AST-138B

### DIFF
--- a/amaranth/vendor/_gowin.py
+++ b/amaranth/vendor/_gowin.py
@@ -204,9 +204,9 @@ class GowinPlatform(TemplatedPlatform):
         # These regular expressions match all >900 parts of Gowin device_info.csv
         reg_series    = r"(GW[125]{1}[AN]{1}[EFNRSZT]{0,3})-"
         reg_voltage   = r"(ZV|EV|LV|LX|UV|UX)"
-        reg_size      = r"(1|2|4|9|15|18|55)"
+        reg_size      = r"(1|2|4|9|15|18|55|138)"
         reg_subseries = r"(?:(A|B|C|S|X|P5)?)"
-        reg_package   = r"((?:PG|UG|EQ|LQ|MG|M|QN|CS|FN)(?:\d+)(?:P?)(?:A|E|M|CF|C|D|G|H|F|S|T|U|X)?)"
+        reg_package   = r"((?:FPG|PG|UG|EQ|LQ|MG|M|QN|CS|FN)(?:\d+)(?:P?)(?:A|E|M|CF|C|D|G|H|F|S|T|U|X)?)"
         reg_speed     = r"((?:C\d{1}/I\d{1})|ES|A\d{1}|I\d{1})"
 
         match = re.match(reg_series+reg_voltage+reg_size+reg_subseries+reg_package+reg_speed+"$",


### PR DESCRIPTION
Hi,

This PR adds support ofr GW5AST-138B. Tested working with vendor toolchain.

---

Update family/part parsing regexes.