### PR TITLE
build.plat: Skip ports with empty metadata

### DIFF
--- a/amaranth/build/plat.py
+++ b/amaranth/build/plat.py
@@ -178,9 +178,13 @@ class Platform(ResourceManager, metaclass=ABCMeta):
     def iter_port_constraints_bits(self):
         for (name, port, _dir) in self._design.ports:
             if len(port) == 1:
+                if port.metadata[0] is None:
+                    continue
                 yield name, port.metadata[0].name, port.metadata[0].attrs
             else:
                 for bit, meta in enumerate(port.metadata):
+                    if meta is None:
+                        continue
                     yield f"{name}[{bit}]", meta.name, meta.attrs
 
     @abstractmethod


### PR DESCRIPTION
Skip yielding ports with None metadata. This change fixes a bug which prevents building a design using IOPort instances with no metadata (required by some Gowin IP cores).