### PR TITLE
gowin: Fix parsing for all Gowin v1.9.12.02_SP2 supported parts

### DIFF
--- a/amaranth/vendor/_gowin.py
+++ b/amaranth/vendor/_gowin.py
@@ -205,7 +205,7 @@ class GowinPlatform(TemplatedPlatform):
         reg_series    = r"(GW[1235]{1}[AN]{1}[EFNRSZT]{0,3})-"
         reg_voltage   = r"(ZV|EV|LV|LX|UV|UX)"
         reg_size      = r"(1|2|3|4|5|9|15|18|20|25|55|60|75|138)"
-        reg_subseries = r"(?:(A|B|C|S|X|P5)?)"
+        reg_subseries = r"(?:(A|B|C|D|ES|P5|P5B|P5C|S|SA|X)?)"
         reg_package   = r"((?:FPG|PG|UG|EQ|LQ|MG|M|QN|CS|FN)(?:\d+)(?:P?)(?:A|E|M|CF|C|D|G|H|F|S|T|U|X)?)"
         reg_speed     = r"((?:C\d{1}/I\d{1})|ES|A\d{1}|I\d{1})"
 

--- a/amaranth/vendor/_gowin.py
+++ b/amaranth/vendor/_gowin.py
@@ -202,7 +202,7 @@ class GowinPlatform(TemplatedPlatform):
 
     def parse_part(self):
         # These regular expressions match all >900 parts of Gowin device_info.csv
-        reg_series    = r"(GW[125]{1}[AN]{1}[EFNRSZT]{0,3})-"
+        reg_series    = r"(GW[1235]{1}[AN]{1}[EFNRSZT]{0,3})-"
         reg_voltage   = r"(ZV|EV|LV|LX|UV|UX)"
         reg_size      = r"(1|2|3|4|5|9|15|18|20|25|55|60|75|138)"
         reg_subseries = r"(?:(A|B|C|S|X|P5)?)"

--- a/amaranth/vendor/_gowin.py
+++ b/amaranth/vendor/_gowin.py
@@ -206,7 +206,7 @@ class GowinPlatform(TemplatedPlatform):
         reg_voltage   = r"(ZV|EV|LV|LX|UV|UX)"
         reg_size      = r"(1|2|3|4|5|9|15|18|20|25|55|60|75|138)"
         reg_subseries = r"(?:(A|B|C|D|ES|P5|P5B|P5C|S|SA|X)?)"
-        reg_package   = r"((?:FPG|PG|UG|EQ|LQ|MG|M|QN|CS|FN)(?:\d+)(?:P?)(?:A|E|M|CF|C|D|G|H|F|S|T|U|X)?)"
+        reg_package   = r"((?:FPG|PG|UG|EQ|LQ|MG|M|QN|CS|FN|CG|SFN|CM)(?:\d+)(?:P?)(?:A|C|CF|D|E|F|G|H|M|N|S|SF|T|U|X|XF)?)"
         reg_speed     = r"((?:C\d{1}/I\d{1})|ES|A\d{1}|C\d{1}|I\d{1})"
 
         match = re.match(reg_series+reg_voltage+reg_size+reg_subseries+reg_package+reg_speed+"$",

--- a/amaranth/vendor/_gowin.py
+++ b/amaranth/vendor/_gowin.py
@@ -207,7 +207,7 @@ class GowinPlatform(TemplatedPlatform):
         reg_size      = r"(1|2|3|4|5|9|15|18|20|25|55|60|75|138)"
         reg_subseries = r"(?:(A|B|C|D|ES|P5|P5B|P5C|S|SA|X)?)"
         reg_package   = r"((?:FPG|PG|UG|EQ|LQ|MG|M|QN|CS|FN)(?:\d+)(?:P?)(?:A|E|M|CF|C|D|G|H|F|S|T|U|X)?)"
-        reg_speed     = r"((?:C\d{1}/I\d{1})|ES|A\d{1}|I\d{1})"
+        reg_speed     = r"((?:C\d{1}/I\d{1})|ES|A\d{1}|C\d{1}|I\d{1})"
 
         match = re.match(reg_series+reg_voltage+reg_size+reg_subseries+reg_package+reg_speed+"$",
                          self.part)

--- a/amaranth/vendor/_gowin.py
+++ b/amaranth/vendor/_gowin.py
@@ -204,7 +204,7 @@ class GowinPlatform(TemplatedPlatform):
         # These regular expressions match all >900 parts of Gowin device_info.csv
         reg_series    = r"(GW[125]{1}[AN]{1}[EFNRSZT]{0,3})-"
         reg_voltage   = r"(ZV|EV|LV|LX|UV|UX)"
-        reg_size      = r"(1|2|4|9|15|18|55|138)"
+        reg_size      = r"(1|2|3|4|5|9|15|18|20|25|55|60|75|138)"
         reg_subseries = r"(?:(A|B|C|S|X|P5)?)"
         reg_package   = r"((?:FPG|PG|UG|EQ|LQ|MG|M|QN|CS|FN)(?:\d+)(?:P?)(?:A|E|M|CF|C|D|G|H|F|S|T|U|X)?)"
         reg_speed     = r"((?:C\d{1}/I\d{1})|ES|A\d{1}|I\d{1})"


### PR DESCRIPTION
Hi,

This PR fixes part/family parsing for all the parts listed in `device_info.csv` of the latest release of Gowin IDE (V1.9.12.02_SP2).

The test script I used looks like this:

```python
from amaranth import *
from amaranth.build import *
from amaranth.vendor import GowinPlatform

import csv


class TestPlatform(GowinPlatform):
    part        = ""
    family      = ""
    device      = ""
    default_clk = ""

    resources   = []
    connectors = []


class Top(Elaboratable):
    def elaborate(self, platform):
        m = Module()
        return m


if __name__ == "__main__":
    with open("device_info.csv", "r") as f:
        reader = csv.reader(f)
        for row in reader:
            TestPlatform.part = row[1]
            TestPlatform.family = row[3]
            TestPlatform.device = row[3]
            try:
                TestPlatform(toolchain="Gowin").build(Top(), do_program=False, do_build=False)
            except Exception as e:
                print(f"Failed: {row[1]} ({row[3]}) with error: {e}")
```