### PR TITLE
gowin: Add support for .csr files

### DIFF
--- a/amaranth/vendor/_gowin.py
+++ b/amaranth/vendor/_gowin.py
@@ -434,6 +434,9 @@ class GowinPlatform(TemplatedPlatform):
             {% for file in platform.iter_files(".v",".sv",".vhd",".vhdl") -%}
                 add_file {{file}}
             {% endfor %}
+            {% for file in platform.iter_files(".csr") -%}
+                set_csr {{file}}
+            {% endfor %}
             add_file -type verilog {{name}}.v
             add_file -type cst {{name}}.cst
             add_file -type sdc {{name}}.sdc


### PR DESCRIPTION
Hi,

This pull request issues the "set_csr" Tcl command when .csr files are supplied to the platform.

CSR files contain configuration values for hard IPs which are loaded during the startup process of the FPGA. These values are part of the bitstream, and are generated using the IP Generation tool.

_Excerpt of a CSR file:_

```
upar_write_driver(0x8081a4,0x0000000C)
upar_write_driver(0x8081a8,0x04F00000)
upar_write_driver(0x808758,0x000000C0)
upar_write_driver(0x808284,0x00000100)
upar_write_driver(0x808384,0x00000100)
upar_write_driver(0x808484,0x00000100)
upar_write_driver(0x808584,0x00000100)
upar_write_driver(0xb00000,0x00FFAA55)
upar_write_driver(0x808104,0x00022322)
upar_write_driver(0x808000,0x00022322)
```