### PR TITLE
vendor._gowin: (Apicula) add -family option to synth_gowin call

### DIFF
--- a/amaranth/vendor/_gowin.py
+++ b/amaranth/vendor/_gowin.py
@@ -387,7 +387,7 @@ class GowinPlatform(TemplatedPlatform):
             {% endfor %}
             read_rtlil {{name}}.il
             {{get_override("script_after_read")|default("# (script_after_read placeholder)")}}
-            synth_gowin {{get_override("synth_opts")|options}} -top {{name}} -json {{name}}.syn.json
+            synth_gowin {{get_override("synth_opts")|options}} -family {{platform.series[:4].lower()}} -top {{name}} -json {{name}}.syn.json
             {{get_override("script_after_synth")|default("# (script_after_synth placeholder)")}}
         """,
     }


### PR DESCRIPTION
Fixes #1673. Per observations in issue report, this may require an updated yosys which understands the `-family` option to `synth_gowin`, but Amaranth 0.6.0 will require a yosys that's new enough to contain `nextpnr-himbaechel` anyway. Given this concern, this PR should not be back-ported to 0.5.x or earlier.

This will only affect code that targets Gowin family-specific cells that differ across Gowin families (GW1N, GW2A, GW5A), of which there are none within Amaranth-lang itself, or in the Gowin-based boards in Amaranth-boards that I have access to.

Tested on Sipeed Tang Primer 20k + Dock hardware, based on GW2A-LV18PG256C8/I7