### PR TITLE
docs: stdlib.stream: Fix bit values in serial receiver example

### DIFF
--- a/docs/stdlib/stream.rst
+++ b/docs/stdlib/stream.rst
@@ -173,7 +173,7 @@ The serial protocol recognized by the receiver is illustrated with the following
                 "serial",
                 { name: "ssel",    wave: "01................0.." },
                 { name: "sclk",    wave: "0..101010101010101..." },
-                { name: "sdat",    wave: "0.=.=.=.=.=.=.=.=....", data: ["1", "0", "1", "0", "0", "0", "0", "1"] },
+                { name: "sdat",    wave: "0.=.=.=.=.=.=.=.=....", data: ["1", "0", "1", "0", "0", "1", "1", "1"] },
             ],
             {},
             [


### PR DESCRIPTION
The example code uses the bit pattern 0b1010'0111.