### PR TITLE
CI: drop Python 3.8 [v0.5]

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,14 +11,12 @@ jobs:
     strategy:
       matrix:
         python-version:
-        - '3.8'
         - '3.9'
         - '3.10'
         - '3.11'
         - '3.12'
         - '3.13'
         - '3.14'
-        - 'pypy-3.8'
         - 'pypy-3.9'
         - 'pypy-3.10'
         - 'pypy-3.11'


### PR DESCRIPTION
PDM no longer runs on this Python version.